### PR TITLE
fix: use standard account only for SPV wallet creation

### DIFF
--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::ffi::{c_void, CStr, CString};
 use std::os::raw::c_char;
 use std::path::PathBuf;
@@ -555,7 +556,14 @@ impl SpvBackend for FfiBackend {
                 &mnemonic_str,
                 "",
                 0,
-                WalletAccountCreationOptions::default(),
+                WalletAccountCreationOptions::SpecificAccounts(
+                    BTreeSet::from([0]),
+                    BTreeSet::new(),
+                    BTreeSet::new(),
+                    BTreeSet::new(),
+                    BTreeSet::new(),
+                    None,
+                ),
             )
             .map_err(|e| BackendError::Internal(e.to_string()))?;
 

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -239,7 +240,14 @@ impl SpvBackend for NativeBackend {
                 mnemonic,
                 "",
                 0,
-                WalletAccountCreationOptions::default(),
+                WalletAccountCreationOptions::SpecificAccounts(
+                    BTreeSet::from([0]),
+                    BTreeSet::new(),
+                    BTreeSet::new(),
+                    BTreeSet::new(),
+                    BTreeSet::new(),
+                    None,
+                ),
             )
             .map_err(|e| match e {
                 key_wallet_manager::WalletError::InvalidMnemonic(msg) => {
@@ -268,7 +276,14 @@ impl SpvBackend for NativeBackend {
                 &mnemonic,
                 "",
                 0,
-                WalletAccountCreationOptions::default(),
+                WalletAccountCreationOptions::SpecificAccounts(
+                    BTreeSet::from([0]),
+                    BTreeSet::new(),
+                    BTreeSet::new(),
+                    BTreeSet::new(),
+                    BTreeSet::new(),
+                    None,
+                ),
             )
             .map_err(|e| BackendError::Internal(e.to_string()))?;
         Ok(true)
@@ -327,7 +342,7 @@ impl SpvBackend for NativeBackend {
             .wallet_transaction_history(wallet_id)
             .map_err(|e| BackendError::Internal(e.to_string()))?;
 
-        let transactions = records
+        let mut transactions: Vec<TransactionInfo> = records
             .into_iter()
             .map(|r| {
                 let direction = if r.net_amount >= 0 {
@@ -349,6 +364,15 @@ impl SpvBackend for NativeBackend {
                 }
             })
             .collect();
+
+        // Sort: unconfirmed first, then by timestamp descending
+        transactions.sort_by(|a, b| {
+            match (a.height.is_some(), b.height.is_some()) {
+                (false, true) => std::cmp::Ordering::Less,
+                (true, false) => std::cmp::Ordering::Greater,
+                _ => b.timestamp.cmp(&a.timestamp),
+            }
+        });
 
         Ok(transactions)
     }

--- a/tests/dashd_sync/tests_native.rs
+++ b/tests/dashd_sync/tests_native.rs
@@ -97,14 +97,13 @@ async fn native_full_sync_with_wallet() {
     // may not detect every transaction the dashd wallet knows about (e.g.,
     // self-sends that only touch change addresses outside the bloom filter).
     let txs = backend.get_transactions().unwrap();
-    let baseline = ctx.dashd.wallet.transaction_count;
-    let min_expected = baseline * 9 / 10; // allow up to 10% fewer
-    assert!(
-        txs.len() >= min_expected && txs.len() <= baseline,
-        "Transaction count {} outside expected range [{}, {}]",
+    let expected_tx_count = ctx.dashd.wallet.unique_txid_count();
+    assert_eq!(
         txs.len(),
-        min_expected,
-        baseline,
+        expected_tx_count,
+        "Transaction count mismatch: expected {}, got {}",
+        expected_tx_count,
+        txs.len(),
     );
 
     // Verify chain tip height matches dashd height.
@@ -539,7 +538,7 @@ async fn native_transaction_count_increases_during_sync() {
     // Allow time for final wallet events.
     wait_for_positive_balance(&mut backend.subscribe_events(), Duration::from_secs(10)).await;
     let txs = backend.get_transactions().unwrap();
-    let baseline = ctx.dashd.wallet.transaction_count;
+    let baseline = ctx.dashd.wallet.unique_txid_count();
     let min_expected = baseline * 9 / 10;
     assert!(
         txs.len() >= min_expected && txs.len() <= baseline,


### PR DESCRIPTION
## Summary

- Use `WalletAccountCreationOptions::SpecificAccounts` with only standard account 0 instead of `Default` (which creates 12+ platform accounts unnecessary for SPV)
- Matches the dash-spv test baseline wallet configuration
- Revert integration test assertions from 90% threshold back to exact transaction count match

Closes #41
