### PR TITLE
fix: move event bridge to AppLayout so all screens get live updates

### DIFF
--- a/src/components/layout.rs
+++ b/src/components/layout.rs
@@ -8,6 +8,8 @@ use crate::components::dev_panel::DevPanel;
 use crate::components::sidebar::Sidebar;
 use crate::components::status_bar::StatusBar;
 use crate::config::AppConfig;
+use crate::event_bridge::use_event_bridge;
+use crate::state::wallet::WalletState;
 
 #[component]
 pub fn AppLayout() -> Element {
@@ -26,9 +28,38 @@ pub fn AppLayout() -> Element {
         }
     });
 
+    // Pipe backend events into reactive UI signals for all screens.
+    use_event_bridge();
+
+    let backend = use_context::<Signal<Backend>>();
+    let wallet = use_context::<Signal<WalletState>>();
+
+    // Load persisted wallet and auto-connect if not already running.
+    use_future(move || async move {
+        let _ = backend.read().load_wallet().await;
+        if !backend.read().is_running() {
+            let _ = backend.read().start().await;
+        }
+    });
+
+    // Load persisted transactions and balance on first mount only.
+    use_future(move || {
+        let mut wallet_state = wallet;
+        async move {
+            if !wallet_state.read().transactions.is_empty() {
+                return;
+            }
+            if let Ok(txs) = backend.read().get_transactions() {
+                wallet_state.write().set_transactions(txs);
+            }
+            if let Ok(balance) = backend.read().get_balance() {
+                wallet_state.write().balance = balance;
+            }
+        }
+    });
+
     // Stop the backend and persist window size when the component unmounts (app close).
     let window = use_window();
-    let backend = use_context::<Signal<Backend>>();
     use_drop(move || {
         if backend.read().is_running() {
             let rt = tokio::runtime::Runtime::new().expect("failed to create shutdown runtime");

--- a/src/screens/dashboard.rs
+++ b/src/screens/dashboard.rs
@@ -1,10 +1,7 @@
 use dioxus::prelude::*;
 
-use crate::backend::dispatch::Backend;
-use crate::backend::r#trait::SpvBackend;
 use crate::backend::types::TransactionDirection;
 use crate::config::AppConfig;
-use crate::event_bridge::use_event_bridge;
 use crate::router::Route;
 use crate::state::network::NetworkInfo;
 use crate::state::view_models::{
@@ -16,37 +13,9 @@ const DASHBOARD_TX_LIMIT: usize = 5;
 
 #[component]
 pub fn Dashboard() -> Element {
-    let backend = use_context::<Signal<Backend>>();
     let wallet = use_context::<Signal<WalletState>>();
     let network_info = use_context::<Signal<NetworkInfo>>();
     let config = use_context::<Signal<AppConfig>>();
-
-    // Start the event bridge coroutine to pipe backend events into UI state.
-    use_event_bridge();
-
-    // Load persisted wallet and auto-connect if not already running.
-    use_future(move || async move {
-        let _ = backend.read().load_wallet().await;
-        if !backend.read().is_running() {
-            let _ = backend.read().start().await;
-        }
-    });
-
-    // Load persisted transactions and balance on first mount only.
-    use_future(move || {
-        let mut wallet_state = wallet;
-        async move {
-            if !wallet_state.read().transactions.is_empty() {
-                return;
-            }
-            if let Ok(txs) = backend.read().get_transactions() {
-                wallet_state.write().set_transactions(txs);
-            }
-            if let Ok(balance) = backend.read().get_balance() {
-                wallet_state.write().balance = balance;
-            }
-        }
-    });
 
     let mut expanded_txid = use_signal(|| None::<dashcore::Txid>);
 


### PR DESCRIPTION
Moves `use_event_bridge()`, auto-start, and initial wallet load from Dashboard to AppLayout. Dashboard is now a pure display component.

Fixes the Transactions screen not updating during sync — events now flow regardless of which screen is active.

Closes #54