### PR TITLE
chore: rename to dash-spv-wallet, switch to git deps with upstream patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,6 +1012,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#632893bda816c7f9f492ac6350993755e70b9773"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1046,6 +1047,7 @@ dependencies = [
 [[package]]
 name = "dash-spv-ffi"
 version = "0.42.0"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#632893bda816c7f9f492ac6350993755e70b9773"
 dependencies = [
  "cbindgen",
  "clap",
@@ -1068,7 +1070,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "dash-spv-ui"
+name = "dash-spv-wallet"
 version = "0.1.0"
 dependencies = [
  "clap",
@@ -1092,6 +1094,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.42.0"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#632893bda816c7f9f492ac6350993755e70b9773"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1116,10 +1119,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.42.0"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#632893bda816c7f9f492ac6350993755e70b9773"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#632893bda816c7f9f492ac6350993755e70b9773"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1132,6 +1137,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#632893bda816c7f9f492ac6350993755e70b9773"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1146,6 +1152,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#632893bda816c7f9f492ac6350993755e70b9773"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -3012,6 +3019,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#632893bda816c7f9f492ac6350993755e70b9773"
 dependencies = [
  "aes",
  "async-trait",
@@ -3039,6 +3047,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.42.0"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#632893bda816c7f9f492ac6350993755e70b9773"
 dependencies = [
  "cbindgen",
  "dashcore",
@@ -3053,6 +3062,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.42.0"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#632893bda816c7f9f492ac6350993755e70b9773"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
-name = "dash-spv-ui"
+name = "dash-spv-wallet"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.89"
 description = "Cross-platform Dash SPV wallet GUI"
 license = "MIT"
-repository = "https://github.com/xdustinface/dash-spv-ui"
+repository = "https://github.com/xdustinface/dash-spv-wallet"
 
 [lib]
-name = "dash_spv_ui"
+name = "dash_spv_wallet"
 path = "src/lib.rs"
 
 [[bin]]
-name = "dash-spv-ui"
+name = "dash-spv-wallet"
 path = "src/main.rs"
 
 [dependencies]
-dashcore = { path = "../rust-dashcore-spv-ui/dash", features = ["serde"] }
-dash-spv = { path = "../rust-dashcore-spv-ui/dash-spv" }
-key-wallet = { path = "../rust-dashcore-spv-ui/key-wallet" }
-key-wallet-manager = { path = "../rust-dashcore-spv-ui/key-wallet-manager" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev", features = ["serde"] }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev" }
 
-dash-spv-ffi = { path = "../rust-dashcore-spv-ui/dash-spv-ffi", optional = true }
-key-wallet-ffi = { path = "../rust-dashcore-spv-ui/key-wallet-ffi", optional = true }
+dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev", optional = true }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev", optional = true }
 
 dioxus = { version = "0.7", features = ["desktop", "router"] }
 clap = { version = "4", features = ["derive"] }
@@ -38,5 +38,14 @@ tracing = "0.1"
 ffi = ["dep:dash-spv-ffi", "dep:key-wallet-ffi"]
 
 [dev-dependencies]
-dash-spv = { path = "../rust-dashcore-spv-ui/dash-spv", features = ["test-utils"] }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev", features = ["test-utils"] }
 tempfile = "3"
+
+# Temporary: use fork with dash-spv-wallet specific changes until merged upstream
+[patch."https://github.com/dashpay/rust-dashcore"]
+dashcore = { git = "https://github.com/xdustinface/rust-dashcore", branch = "feat/dash-spv-wallet" }
+dash-spv = { git = "https://github.com/xdustinface/rust-dashcore", branch = "feat/dash-spv-wallet" }
+key-wallet = { git = "https://github.com/xdustinface/rust-dashcore", branch = "feat/dash-spv-wallet" }
+key-wallet-manager = { git = "https://github.com/xdustinface/rust-dashcore", branch = "feat/dash-spv-wallet" }
+dash-spv-ffi = { git = "https://github.com/xdustinface/rust-dashcore", branch = "feat/dash-spv-wallet" }
+key-wallet-ffi = { git = "https://github.com/xdustinface/rust-dashcore", branch = "feat/dash-spv-wallet" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 // Re-export library modules so binary-only modules can use `crate::backend` and `crate::config`.
-use dash_spv_ui::backend;
-use dash_spv_ui::config;
+use dash_spv_wallet::backend;
+use dash_spv_wallet::config;
 
 mod components;
 mod event_bridge;

--- a/tests/dashd_sync/helpers.rs
+++ b/tests/dashd_sync/helpers.rs
@@ -2,8 +2,8 @@ use std::collections::HashSet;
 use std::time::Duration;
 
 use dash_spv::test_utils::SYNC_TIMEOUT;
-use dash_spv_ui::backend::events::{EventReceiver, SpvEvent};
-use dash_spv_ui::backend::types::{TransactionInfo, WalletCoreBalance};
+use dash_spv_wallet::backend::events::{EventReceiver, SpvEvent};
+use dash_spv_wallet::backend::types::{TransactionInfo, WalletCoreBalance};
 
 use super::setup::is_sync_complete;
 

--- a/tests/dashd_sync/setup.rs
+++ b/tests/dashd_sync/setup.rs
@@ -1,6 +1,6 @@
 use dash_spv::test_utils::{DashdTestContext, TestChain};
-use dash_spv_ui::backend::events::SpvEvent;
-use dash_spv_ui::config::AppConfig;
+use dash_spv_wallet::backend::events::SpvEvent;
+use dash_spv_wallet::config::AppConfig;
 use dashcore::Network;
 use tempfile::TempDir;
 

--- a/tests/dashd_sync/tests_ffi.rs
+++ b/tests/dashd_sync/tests_ffi.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use dash_spv::test_utils::TestChain;
-use dash_spv_ui::backend::ffi::FfiBackend;
-use dash_spv_ui::backend::r#trait::SpvBackend;
+use dash_spv_wallet::backend::ffi::FfiBackend;
+use dash_spv_wallet::backend::r#trait::SpvBackend;
 use dashcore::Network;
 
 use super::helpers::{

--- a/tests/dashd_sync/tests_native.rs
+++ b/tests/dashd_sync/tests_native.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
 use dash_spv::test_utils::TestChain;
-use dash_spv_ui::backend::error::BackendError;
-use dash_spv_ui::backend::native::NativeBackend;
-use dash_spv_ui::backend::r#trait::SpvBackend;
-use dash_spv_ui::backend::types::TransactionDirection;
+use dash_spv_wallet::backend::error::BackendError;
+use dash_spv_wallet::backend::native::NativeBackend;
+use dash_spv_wallet::backend::r#trait::SpvBackend;
+use dash_spv_wallet::backend::types::TransactionDirection;
 use dashcore::hashes::Hash;
 use dashcore::Network;
 


### PR DESCRIPTION
## Summary

- Rename crate from `dash-spv-ui` to `dash-spv-wallet` (package name, lib name, bin name)
- Update repository URL to `xdustinface/dash-spv-wallet`
- Switch from path dependencies to git dependencies pointing at `dashpay/rust-dashcore` v0.42-dev
- `[patch]` section temporarily redirects to `xdustinface/rust-dashcore` feat/dash-spv-wallet branch
- Update all `use dash_spv_ui::` to `use dash_spv_wallet::` in tests
- Add `crash.log` to `.gitignore`
