### PR TITLE
fix: UI sync status gets stuck — increase channel capacity and add lag recovery

### DIFF
--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -83,7 +83,7 @@ unsafe impl Sync for FfiBackend {}
 
 impl FfiBackend {
     pub fn new(config: AppConfig) -> Self {
-        let (event_tx, _) = event_channel(256);
+        let (event_tx, _) = event_channel(4096);
 
         Self {
             config,

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -54,7 +54,7 @@ impl NativeBackend {
     pub fn new(config: AppConfig) -> Self {
         let wallet_manager = WalletManager::<ManagedWalletInfo>::new(config.network);
         let wallet = Arc::new(tokio::sync::RwLock::new(wallet_manager));
-        let (event_tx, _) = event_channel(256);
+        let (event_tx, _) = event_channel(4096);
 
         Self {
             config,

--- a/src/event_bridge.rs
+++ b/src/event_bridge.rs
@@ -36,7 +36,9 @@ pub fn use_event_bridge() {
                     tracing::warn!("Event bridge lagged, skipped {n} events");
                     // Re-query backend state to catch up on missed events
                     let progress = backend.read().sync_progress();
-                    connection.write().apply_event(&SpvEvent::SyncProgressUpdated(Box::new(progress)));
+                    connection
+                        .write()
+                        .apply_event(&SpvEvent::SyncProgressUpdated(Box::new(progress)));
                     if let Ok(balance) = backend.read().get_balance() {
                         wallet.write().balance = balance;
                     }

--- a/src/event_bridge.rs
+++ b/src/event_bridge.rs
@@ -1,7 +1,6 @@
 use dioxus::prelude::*;
 
 use crate::backend::dispatch::Backend;
-use crate::backend::events::SpvEvent;
 use crate::backend::r#trait::SpvBackend;
 use crate::state::connection::ConnectionState;
 use crate::state::dev_log::DevLog;
@@ -10,9 +9,9 @@ use crate::state::wallet::WalletState;
 
 /// Spawns a coroutine that bridges async backend events into reactive UI signals.
 ///
-/// Call this once from a component that has all the required context signals
-/// (e.g., the Dashboard). The coroutine subscribes to the backend event channel
-/// and updates `ConnectionState`, `WalletState`, `NetworkInfo`, and `DevLog`
+/// Call this once from a component that has all the required context signals.
+/// The coroutine subscribes to the backend event channel and updates
+/// `ConnectionState`, `WalletState`, `NetworkInfo`, and `DevLog`
 /// on each received event.
 pub fn use_event_bridge() {
     let backend = use_context::<Signal<Backend>>();
@@ -33,15 +32,7 @@ pub fn use_event_bridge() {
                     dev_log.write().push(&event);
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    tracing::warn!("Event bridge lagged, skipped {n} events");
-                    // Re-query backend state to catch up on missed events
-                    let progress = backend.read().sync_progress();
-                    connection
-                        .write()
-                        .apply_event(&SpvEvent::SyncProgressUpdated(Box::new(progress)));
-                    if let Ok(balance) = backend.read().get_balance() {
-                        wallet.write().balance = balance;
-                    }
+                    tracing::error!("Event bridge lost {n} events — UI state may be inconsistent");
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                     break;

--- a/src/event_bridge.rs
+++ b/src/event_bridge.rs
@@ -1,6 +1,7 @@
 use dioxus::prelude::*;
 
 use crate::backend::dispatch::Backend;
+use crate::backend::events::SpvEvent;
 use crate::backend::r#trait::SpvBackend;
 use crate::state::connection::ConnectionState;
 use crate::state::dev_log::DevLog;
@@ -33,6 +34,12 @@ pub fn use_event_bridge() {
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                     tracing::warn!("Event bridge lagged, skipped {n} events");
+                    // Re-query backend state to catch up on missed events
+                    let progress = backend.read().sync_progress();
+                    connection.write().apply_event(&SpvEvent::SyncProgressUpdated(Box::new(progress)));
+                    if let Ok(balance) = backend.read().get_balance() {
+                        wallet.write().balance = balance;
+                    }
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                     break;


### PR DESCRIPTION
- Broadcast channel capacity 256 → 4096 (NativeBackend + FfiBackend)
- Event bridge: on lag, re-queries sync_progress() and get_balance() to catch up

Closes #49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter handling of event subscription lag: lost events are now reported and potential UI inconsistency is signaled.
* **Performance**
  * Increased event queue capacity to better handle higher event volumes and reduce risk of dropped or stalled events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->