### PR TITLE
fix: update README badge URLs to dash-spv-wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/xdustinface/dash-spv-ui/actions/workflows/ci.yml">
-    <img alt="CI" src="https://github.com/xdustinface/dash-spv-ui/actions/workflows/ci.yml/badge.svg?branch=dev">
+  <a href="https://github.com/xdustinface/dash-spv-wallet/actions/workflows/ci.yml">
+    <img alt="CI" src="https://github.com/xdustinface/dash-spv-wallet/actions/workflows/ci.yml/badge.svg?branch=dev">
   </a>
-  <a href="https://codecov.io/gh/xdustinface/dash-spv-ui">
-    <img alt="Coverage" src="https://codecov.io/gh/xdustinface/dash-spv-ui/branch/dev/graph/badge.svg">
+  <a href="https://codecov.io/gh/xdustinface/dash-spv-wallet">
+    <img alt="Coverage" src="https://codecov.io/gh/xdustinface/dash-spv-wallet/branch/dev/graph/badge.svg">
   </a>
 </p>
 


### PR DESCRIPTION
CI and Codecov badges still pointed to the old repo name `dash-spv-ui`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI and code coverage badge references to point to the correct repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->