### PR TITLE
fix: make Generate Address button smaller and less prominent

### DIFF
--- a/src/screens/receive.rs
+++ b/src/screens/receive.rs
@@ -93,7 +93,7 @@ pub fn Receive() -> Element {
                 }
 
                 button {
-                    class: "w-full bg-dash hover:bg-dash-hover text-foreground font-medium py-2 px-4 rounded-lg transition-colors",
+                    class: "bg-card hover:bg-hover text-muted text-sm py-2 px-4 rounded-lg transition-colors",
                     onclick: generate_address,
                     "Generate New Address"
                 }


### PR DESCRIPTION
Secondary styling — not full width, smaller text, muted colors.

Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the "Generate New Address" button appearance with updated colors, hover effects, and text styling for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->