### PR TITLE
fix: panic on event bridge lag instead of silently losing state

### DIFF
--- a/src/event_bridge.rs
+++ b/src/event_bridge.rs
@@ -32,7 +32,10 @@ pub fn use_event_bridge() {
                     dev_log.write().push(&event);
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    tracing::error!("Event bridge lost {n} events — UI state may be inconsistent");
+                    panic!(
+                        "Event bridge lost {n} events — this is a bug. \
+                         Increase the event channel capacity or reduce event volume."
+                    );
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                     break;


### PR DESCRIPTION
Event loss is now a fatal error (panic) instead of a silent log. There's no way to recover lost events, so continuing with inconsistent state is worse than crashing.

Closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated event handling to trigger a critical failure with diagnostic information when the event queue reaches capacity, providing guidance on adjusting system configuration to prevent message loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->