### PR TITLE
test: add coverage for `BackendError` display and `Backend` dispatch

### DIFF
--- a/src/backend/dispatch.rs
+++ b/src/backend/dispatch.rs
@@ -153,3 +153,151 @@ impl SpvBackend for Backend {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::error::BackendError;
+    use super::super::types::{Network, SyncState};
+    use super::*;
+
+    const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    fn mock_backend(network: Network) -> Backend {
+        Backend::Mock(MockBackend::builder(network).build())
+    }
+
+    fn mock_backend_with_wallet(network: Network, balance: u64) -> Backend {
+        Backend::Mock(
+            MockBackend::builder(network)
+                .with_confirmed_balance(balance)
+                .with_persisted_wallet()
+                .build(),
+        )
+    }
+
+    #[tokio::test]
+    async fn dispatch_start_stop_is_running() {
+        let backend = mock_backend(Network::Testnet);
+
+        assert!(!backend.is_running());
+        backend.start().await.unwrap();
+        assert!(backend.is_running());
+        backend.stop().await.unwrap();
+        assert!(!backend.is_running());
+    }
+
+    #[test]
+    fn dispatch_network() {
+        assert_eq!(mock_backend(Network::Testnet).network(), Network::Testnet);
+        assert_eq!(mock_backend(Network::Mainnet).network(), Network::Mainnet);
+        assert_eq!(mock_backend(Network::Regtest).network(), Network::Regtest);
+    }
+
+    #[test]
+    fn dispatch_tip_height() {
+        let backend = Backend::Mock(
+            MockBackend::builder(Network::Testnet)
+                .with_tip_height(12345)
+                .build(),
+        );
+        assert_eq!(backend.tip_height(), Some(12345));
+
+        let backend_no_tip = mock_backend(Network::Testnet);
+        assert_eq!(backend_no_tip.tip_height(), None);
+    }
+
+    #[test]
+    fn dispatch_sync_progress() {
+        let backend = mock_backend(Network::Testnet);
+        let progress = backend.sync_progress();
+        assert_eq!(progress.state(), SyncState::WaitForEvents);
+        assert!(!progress.is_synced());
+    }
+
+    #[test]
+    fn dispatch_generate_mnemonic() {
+        let backend = mock_backend(Network::Testnet);
+        let mnemonic = backend.generate_mnemonic().unwrap();
+        assert_eq!(mnemonic.split_whitespace().count(), 12);
+    }
+
+    #[tokio::test]
+    async fn dispatch_create_wallet() {
+        let backend = mock_backend(Network::Testnet);
+        backend.create_wallet(TEST_MNEMONIC).await.unwrap();
+
+        let err = backend.create_wallet(TEST_MNEMONIC).await.unwrap_err();
+        assert_eq!(err, BackendError::WalletAlreadyExists);
+    }
+
+    #[tokio::test]
+    async fn dispatch_load_wallet() {
+        let no_wallet = mock_backend(Network::Testnet);
+        assert!(!no_wallet.load_wallet().await.unwrap());
+
+        let with_wallet = mock_backend_with_wallet(Network::Testnet, 0);
+        assert!(with_wallet.load_wallet().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn dispatch_get_receive_address() {
+        let backend = mock_backend_with_wallet(Network::Testnet, 100_000);
+        backend.load_wallet().await.unwrap();
+
+        let addr = backend.get_receive_address().unwrap();
+        assert!(addr.starts_with("XmockAddr"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_get_balance() {
+        let backend = mock_backend_with_wallet(Network::Testnet, 500_000);
+        backend.load_wallet().await.unwrap();
+
+        let balance = backend.get_balance().unwrap();
+        assert_eq!(balance.spendable(), 500_000);
+    }
+
+    #[tokio::test]
+    async fn dispatch_get_transactions() {
+        let backend = mock_backend_with_wallet(Network::Testnet, 0);
+        backend.load_wallet().await.unwrap();
+
+        let txs = backend.get_transactions().unwrap();
+        assert!(txs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn dispatch_estimate_fee() {
+        let backend = mock_backend_with_wallet(Network::Testnet, 1_000_000);
+        backend.load_wallet().await.unwrap();
+
+        let fee = backend.estimate_fee("Xaddr", 100_000, 1000).unwrap();
+        assert!(fee > 0);
+    }
+
+    #[tokio::test]
+    async fn dispatch_send() {
+        let backend = mock_backend_with_wallet(Network::Testnet, 1_000_000);
+        backend.load_wallet().await.unwrap();
+
+        let txid = backend.send("Xaddr", 250_000, 1000).await.unwrap();
+        assert_ne!(txid, [0u8; 32]);
+
+        let balance = backend.get_balance().unwrap();
+        assert_eq!(balance.spendable(), 750_000);
+
+        let txs = backend.get_transactions().unwrap();
+        assert_eq!(txs.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn dispatch_subscribe_events() {
+        let backend = mock_backend(Network::Testnet);
+        let mut rx = backend.subscribe_events();
+
+        backend.start().await.unwrap();
+
+        let event = rx.try_recv();
+        assert!(event.is_ok());
+    }
+}

--- a/src/backend/error.rs
+++ b/src/backend/error.rs
@@ -51,3 +51,73 @@ impl std::error::Error for BackendError {}
 
 /// Result type for backend operations.
 pub type BackendResult<T> = Result<T, BackendError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_all_variants() {
+        let cases: Vec<(BackendError, &str)> = vec![
+            (BackendError::NoWallet, "no wallet loaded"),
+            (BackendError::WalletAlreadyExists, "wallet already exists"),
+            (
+                BackendError::InvalidMnemonic("bad phrase".into()),
+                "invalid mnemonic: bad phrase",
+            ),
+            (
+                BackendError::InvalidAddress("wrong network".into()),
+                "invalid address: wrong network",
+            ),
+            (
+                BackendError::InsufficientFunds {
+                    available: 100,
+                    required: 500,
+                },
+                "insufficient funds: have 100, need 500",
+            ),
+            (BackendError::NotRunning, "client is not running"),
+            (BackendError::AlreadyRunning, "client is already running"),
+            (
+                BackendError::Sync("timeout".into()),
+                "sync error: timeout",
+            ),
+            (
+                BackendError::Storage("disk full".into()),
+                "storage error: disk full",
+            ),
+            (
+                BackendError::Internal("unexpected".into()),
+                "internal error: unexpected",
+            ),
+        ];
+
+        for (error, expected) in &cases {
+            assert_eq!(error.to_string(), *expected, "failed for {error:?}");
+        }
+    }
+
+    #[test]
+    fn debug_is_implemented() {
+        let error = BackendError::NoWallet;
+        let debug = format!("{error:?}");
+        assert!(debug.contains("NoWallet"));
+    }
+
+    #[test]
+    fn implements_std_error() {
+        let error = BackendError::Internal("test".into());
+        let std_error: &dyn std::error::Error = &error;
+        assert!(std_error.source().is_none());
+        assert_eq!(std_error.to_string(), "internal error: test");
+    }
+
+    #[test]
+    fn backend_result_ok_and_err() {
+        let ok: BackendResult<u32> = Ok(42);
+        assert!(ok.is_ok());
+
+        let err: BackendResult<u32> = Err(BackendError::NoWallet);
+        assert!(err.is_err());
+    }
+}

--- a/src/backend/error.rs
+++ b/src/backend/error.rs
@@ -78,10 +78,7 @@ mod tests {
             ),
             (BackendError::NotRunning, "client is not running"),
             (BackendError::AlreadyRunning, "client is already running"),
-            (
-                BackendError::Sync("timeout".into()),
-                "sync error: timeout",
-            ),
+            (BackendError::Sync("timeout".into()), "sync error: timeout"),
             (
                 BackendError::Storage("disk full".into()),
                 "storage error: disk full",


### PR DESCRIPTION
## Summary
- Add tests for all 10 `BackendError` Display variants, Debug impl, and Error trait
- Add dispatch tests for every `SpvBackend` method via `Backend::Mock` (start/stop, network, tip_height, sync_progress, wallet CRUD, send, subscribe_events)

Closes #64