### PR TITLE
test: improve coverage for `AppConfig` and `ConnectionState`

### DIFF
--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -285,4 +285,105 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&tmp);
     }
+
+    #[test]
+    fn default_window_dimensions() {
+        let config = AppConfig::default();
+        assert_eq!(config.window_width, 1024);
+        assert_eq!(config.window_height, 768);
+    }
+
+    #[test]
+    fn window_dimensions_from_toml() {
+        let toml_str = r#"
+            network = "testnet"
+            data_dir = "/tmp"
+            dev_mode = false
+            log_level = "info"
+            window_width = 1920
+            window_height = 1080
+        "#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.window_width, 1920);
+        assert_eq!(config.window_height, 1080);
+    }
+
+    #[test]
+    fn window_dimensions_default_when_omitted_from_toml() {
+        let toml_str = r#"
+            network = "testnet"
+            data_dir = "/tmp"
+            dev_mode = false
+            log_level = "info"
+        "#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.window_width, 1024);
+        assert_eq!(config.window_height, 768);
+    }
+
+    #[test]
+    fn skip_fields_not_persisted_in_roundtrip() {
+        let config = AppConfig {
+            mock_mode: true,
+            backend: "ffi".to_string(),
+            peers: vec!["1.2.3.4:9999".to_string()],
+            ..Default::default()
+        };
+
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        let restored: AppConfig = toml::from_str(&toml_str).unwrap();
+
+        assert!(!restored.mock_mode);
+        assert!(restored.backend.is_empty());
+        assert!(restored.peers.is_empty());
+    }
+
+    #[test]
+    fn invalid_toml_produces_parse_error() {
+        let bad_toml = "this is not valid toml {{{}}}";
+        let result = toml::from_str::<AppConfig>(bad_toml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn partial_toml_uses_defaults_for_missing_fields() {
+        let toml_str = r#"
+            network = "mainnet"
+            data_dir = "/data"
+            dev_mode = false
+            log_level = "warn"
+        "#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.network, Network::Mainnet);
+        assert!(config.wallet_dir.is_none());
+        assert_eq!(config.window_width, 1024);
+    }
+
+    #[test]
+    fn config_error_display() {
+        let io_err = ConfigError::Io(io::Error::new(io::ErrorKind::NotFound, "gone"));
+        assert!(io_err.to_string().contains("config I/O error"));
+
+        let parse_err = ConfigError::Parse("bad value".to_string());
+        assert!(parse_err.to_string().contains("config parse error"));
+        assert!(parse_err.to_string().contains("bad value"));
+    }
+
+    #[test]
+    fn ensure_dirs_creates_directories() {
+        let tmp = std::env::temp_dir().join("dash-spv-ui-test-ensure-dirs");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let config = AppConfig {
+            data_dir: tmp.join("data"),
+            wallet_dir: Some(tmp.join("wallets")),
+            ..Default::default()
+        };
+        config.ensure_dirs().unwrap();
+
+        assert!(config.data_dir.exists());
+        assert!(config.wallet_dir().exists());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
 }

--- a/src/state/connection.rs
+++ b/src/state/connection.rs
@@ -187,4 +187,199 @@ mod tests {
         assert_eq!(view.percentage, 0.0);
         assert_eq!(view.stage_label, "Syncing... (0%)");
     }
+
+    #[test]
+    fn default_connection_state_is_disconnected() {
+        assert_eq!(ConnectionState::default(), ConnectionState::Disconnected);
+    }
+
+    #[test]
+    fn peer_connected_ignored_when_not_disconnected() {
+        for initial in [
+            ConnectionState::Connecting,
+            ConnectionState::Synced,
+            ConnectionState::Syncing(SyncProgressView {
+                percentage: 50.0,
+                stage_label: "test".into(),
+            }),
+        ] {
+            let mut state = initial.clone();
+            state.apply_event(&SpvEvent::PeerConnected("1.2.3.4:9999".into()));
+            assert_eq!(state, initial);
+        }
+    }
+
+    #[test]
+    fn peer_disconnected_is_noop() {
+        let mut state = ConnectionState::Connecting;
+        state.apply_event(&SpvEvent::PeerDisconnected("1.2.3.4:9999".into()));
+        assert_eq!(state, ConnectionState::Connecting);
+    }
+
+    #[test]
+    fn zero_peers_does_not_override_error() {
+        let mut state = ConnectionState::Error("fatal".into());
+        state.apply_event(&SpvEvent::PeersUpdated {
+            count: 0,
+            best_height: 0,
+        });
+        assert!(matches!(state, ConnectionState::Error(_)));
+    }
+
+    #[test]
+    fn nonzero_peers_is_noop() {
+        let mut state = ConnectionState::Connecting;
+        state.apply_event(&SpvEvent::PeersUpdated {
+            count: 3,
+            best_height: 1000,
+        });
+        assert_eq!(state, ConnectionState::Connecting);
+    }
+
+    #[test]
+    fn sync_progress_updated_ignores_error_state() {
+        let mut state = ConnectionState::Error("broken".into());
+        let progress = SyncProgress::default();
+        state.apply_event(&SpvEvent::SyncProgressUpdated(Box::new(progress)));
+        assert!(matches!(state, ConnectionState::Error(_)));
+    }
+
+    #[test]
+    fn sync_progress_synced_transitions_to_synced() {
+        use dash_spv::sync::{BlockHeadersProgress, FilterHeadersProgress, FiltersProgress};
+
+        let mut progress = SyncProgress::default();
+        let mut headers = BlockHeadersProgress::default();
+        headers.set_state(SyncState::Synced);
+        progress.update_headers(headers);
+        let mut fh = FilterHeadersProgress::default();
+        fh.set_state(SyncState::Synced);
+        progress.update_filter_headers(fh);
+        let mut f = FiltersProgress::default();
+        f.set_state(SyncState::Synced);
+        progress.update_filters(f);
+
+        let mut state = ConnectionState::Connecting;
+        state.apply_event(&SpvEvent::SyncProgressUpdated(Box::new(progress)));
+        assert_eq!(state, ConnectionState::Synced);
+    }
+
+    #[test]
+    fn format_sync_stage_headers() {
+        use dash_spv::sync::BlockHeadersProgress;
+
+        let mut progress = SyncProgress::default();
+        let mut headers = BlockHeadersProgress::default();
+        headers.set_state(SyncState::Syncing);
+        progress.update_headers(headers);
+
+        let view = SyncProgressView::from_progress(&progress);
+        assert_eq!(view.stage_label, "Syncing headers...");
+    }
+
+    #[test]
+    fn format_sync_stage_filter_headers() {
+        use dash_spv::sync::{BlockHeadersProgress, FilterHeadersProgress};
+
+        let mut progress = SyncProgress::default();
+        let mut headers = BlockHeadersProgress::default();
+        headers.set_state(SyncState::Synced);
+        progress.update_headers(headers);
+        let mut fh = FilterHeadersProgress::default();
+        fh.set_state(SyncState::Syncing);
+        progress.update_filter_headers(fh);
+
+        let view = SyncProgressView::from_progress(&progress);
+        assert_eq!(view.stage_label, "Syncing filter headers...");
+    }
+
+    #[test]
+    fn format_sync_stage_filters() {
+        use dash_spv::sync::{BlockHeadersProgress, FilterHeadersProgress, FiltersProgress};
+
+        let mut progress = SyncProgress::default();
+        let mut headers = BlockHeadersProgress::default();
+        headers.set_state(SyncState::Synced);
+        progress.update_headers(headers);
+        let mut fh = FilterHeadersProgress::default();
+        fh.set_state(SyncState::Synced);
+        progress.update_filter_headers(fh);
+        let mut f = FiltersProgress::default();
+        f.set_state(SyncState::Syncing);
+        progress.update_filters(f);
+
+        let view = SyncProgressView::from_progress(&progress);
+        assert_eq!(view.stage_label, "Downloading filters...");
+    }
+
+    #[test]
+    fn format_sync_stage_blocks() {
+        use dash_spv::sync::BlocksProgress;
+
+        let mut progress = SyncProgress::default();
+        let mut blocks = BlocksProgress::default();
+        blocks.set_state(SyncState::Syncing);
+        progress.update_blocks(blocks);
+
+        let view = SyncProgressView::from_progress(&progress);
+        assert_eq!(view.stage_label, "Processing blocks...");
+    }
+
+    #[test]
+    fn format_sync_stage_masternodes() {
+        use dash_spv::sync::MasternodesProgress;
+
+        let mut progress = SyncProgress::default();
+        let mut mn = MasternodesProgress::default();
+        mn.set_state(SyncState::Syncing);
+        progress.update_masternodes(mn);
+
+        let view = SyncProgressView::from_progress(&progress);
+        assert_eq!(view.stage_label, "Syncing masternodes...");
+    }
+
+    #[test]
+    fn format_sync_stage_chainlocks() {
+        use dash_spv::sync::ChainLockProgress;
+
+        let mut progress = SyncProgress::default();
+        let mut cl = ChainLockProgress::default();
+        cl.set_state(SyncState::Syncing);
+        progress.update_chainlocks(cl);
+
+        let view = SyncProgressView::from_progress(&progress);
+        assert_eq!(view.stage_label, "Validating chain locks...");
+    }
+
+    #[test]
+    fn format_sync_stage_instantsend() {
+        use dash_spv::sync::InstantSendProgress;
+
+        let mut progress = SyncProgress::default();
+        let mut is = InstantSendProgress::default();
+        is.set_state(SyncState::Syncing);
+        progress.update_instantsend(is);
+
+        let view = SyncProgressView::from_progress(&progress);
+        assert_eq!(view.stage_label, "Processing instant send...");
+    }
+
+    #[test]
+    fn format_sync_stage_synced() {
+        use dash_spv::sync::{BlockHeadersProgress, FilterHeadersProgress, FiltersProgress};
+
+        let mut progress = SyncProgress::default();
+        let mut headers = BlockHeadersProgress::default();
+        headers.set_state(SyncState::Synced);
+        progress.update_headers(headers);
+        let mut fh = FilterHeadersProgress::default();
+        fh.set_state(SyncState::Synced);
+        progress.update_filter_headers(fh);
+        let mut f = FiltersProgress::default();
+        f.set_state(SyncState::Synced);
+        progress.update_filters(f);
+
+        let view = SyncProgressView::from_progress(&progress);
+        assert_eq!(view.stage_label, "Synced");
+    }
 }


### PR DESCRIPTION
## Summary
- Add tests for `AppConfig` window dimensions, TOML round-trip, partial/invalid TOML, `ConfigError` display, and `ensure_dirs`
- Add tests for `ConnectionState` transitions, `apply_event` edge cases (ignored states, error preservation), and `format_sync_stage` for all progress types

Closes #66