### PR TITLE
test: add SSR render tests for screen components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -84,7 +84,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -104,6 +104,12 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "askama_escape"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df27b8d5ddb458c5fb1bbc1ce172d4a38c614a97d550b0ac89003897fb01de4"
 
 [[package]]
 name = "async-trait"
@@ -1035,6 +1041,8 @@ dependencies = [
  "dash-spv-ffi",
  "dashcore",
  "dioxus",
+ "dioxus-history",
+ "dioxus-ssr",
  "dirs",
  "hex",
  "key-wallet",
@@ -1545,6 +1553,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dioxus-ssr"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44cf9294a21fcd1098e02ad7a3ba61b99be8310ad3395fecf8210387c83f26b9"
+dependencies = [
+ "askama_escape",
+ "dioxus-core",
+ "dioxus-core-types",
+ "rustc-hash 2.1.1",
+]
+
+[[package]]
 name = "dioxus-stores"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,7 +1639,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1820,7 +1840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2825,7 +2845,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3464,7 +3484,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4454,7 +4474,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4950,7 +4970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5201,7 +5221,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6066,7 +6086,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ ffi = ["dep:dash-spv-ffi", "dep:key-wallet-ffi"]
 
 [dev-dependencies]
 dash-spv = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev", features = ["test-utils"] }
+dioxus-history = "0.7"
+dioxus-ssr = "0.7"
 tempfile = "3"
 
 # Temporary: use fork with dash-spv-wallet specific changes until merged upstream

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dash-spv-ui",
+  "name": "dash-spv-wallet",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,7 @@
 pub mod backend;
+pub mod components;
 pub mod config;
+pub mod event_bridge;
+pub mod router;
+pub mod screens;
+pub mod state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,16 @@
-// Re-export library modules so binary-only modules can use `crate::backend` and `crate::config`.
-use dash_spv_wallet::backend;
-use dash_spv_wallet::config;
-
-mod components;
-mod event_bridge;
-mod router;
-mod screens;
-mod state;
-
-use dioxus::prelude::*;
-
-use crate::router::Route;
-use crate::state::app_state::AppState;
-use crate::state::connection::ConnectionState;
-use crate::state::dev_log::DevLog;
-use crate::state::network::NetworkInfo;
-use crate::state::wallet::WalletState;
-use backend::dispatch::Backend;
+use dash_spv_wallet::backend::dispatch::Backend;
 #[cfg(feature = "ffi")]
-use backend::ffi::FfiBackend;
-use backend::mock::MockBackend;
-use backend::native::NativeBackend;
-use config::AppConfig;
+use dash_spv_wallet::backend::ffi::FfiBackend;
+use dash_spv_wallet::backend::mock::MockBackend;
+use dash_spv_wallet::backend::native::NativeBackend;
+use dash_spv_wallet::config::AppConfig;
+use dash_spv_wallet::router::Route;
+use dash_spv_wallet::state::app_state::AppState;
+use dash_spv_wallet::state::connection::ConnectionState;
+use dash_spv_wallet::state::dev_log::DevLog;
+use dash_spv_wallet::state::network::NetworkInfo;
+use dash_spv_wallet::state::wallet::WalletState;
+use dioxus::prelude::*;
 
 fn main() {
     let config = AppConfig::load().unwrap_or_else(|e| {

--- a/src/screens/mod.rs
+++ b/src/screens/mod.rs
@@ -41,7 +41,7 @@ mod tests {
     }
 
     /// Provides all context signals that screen components expect.
-    fn provide_test_contexts() {
+    fn use_test_contexts() {
         use_context_provider(|| Signal::new(test_backend()));
         use_context_provider(|| Signal::new(test_config()));
         use_context_provider(|| Signal::new(AppState::new(false)));
@@ -61,28 +61,33 @@ mod tests {
     // -- Wrapper components for each screen --
     // Each provides context and delegates to the actual screen component.
 
+    #[component]
     fn send_wrapper() -> Element {
-        provide_test_contexts();
+        use_test_contexts();
         super::send::Send()
     }
 
+    #[component]
     fn receive_wrapper() -> Element {
-        provide_test_contexts();
+        use_test_contexts();
         super::receive::Receive()
     }
 
+    #[component]
     fn transactions_wrapper() -> Element {
-        provide_test_contexts();
+        use_test_contexts();
         super::transactions::Transactions()
     }
 
+    #[component]
     fn settings_wrapper() -> Element {
-        provide_test_contexts();
+        use_test_contexts();
         super::settings::Settings()
     }
 
+    #[component]
     fn dashboard_wrapper() -> Element {
-        provide_test_contexts();
+        use_test_contexts();
         super::dashboard::Dashboard()
     }
 
@@ -90,8 +95,9 @@ mod tests {
     /// a `Router::<Route>` with a `MemoryHistory` starting at that path.
     macro_rules! routed_wrapper {
         ($name:ident, $url:expr) => {
+            #[component]
             fn $name() -> Element {
-                provide_test_contexts();
+                use_test_contexts();
                 provide_history_context(Rc::new(MemoryHistory::with_initial_path($url)));
                 rsx! { Router::<Route> {} }
             }

--- a/src/screens/mod.rs
+++ b/src/screens/mod.rs
@@ -7,3 +7,217 @@ pub mod transactions;
 pub mod wallet_choice;
 pub mod wallet_create;
 pub mod wallet_import;
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use std::rc::Rc;
+
+    use dioxus::prelude::*;
+    use dioxus_history::{MemoryHistory, provide_history_context};
+
+    use crate::backend::dispatch::Backend;
+    use crate::backend::mock::MockBackend;
+    use crate::backend::types::Network;
+    use crate::config::AppConfig;
+    use crate::router::Route;
+    use crate::state::app_state::AppState;
+    use crate::state::connection::ConnectionState;
+    use crate::state::dev_log::DevLog;
+    use crate::state::network::NetworkInfo;
+    use crate::state::wallet::WalletState;
+
+    fn test_config() -> AppConfig {
+        AppConfig {
+            network: Network::Testnet,
+            data_dir: PathBuf::from("/tmp/dash-spv-test"),
+            ..Default::default()
+        }
+    }
+
+    fn test_backend() -> Backend {
+        Backend::Mock(MockBackend::builder(Network::Testnet).build())
+    }
+
+    /// Provides all context signals that screen components expect.
+    fn provide_test_contexts() {
+        use_context_provider(|| Signal::new(test_backend()));
+        use_context_provider(|| Signal::new(test_config()));
+        use_context_provider(|| Signal::new(AppState::new(false)));
+        use_context_provider(|| Signal::new(WalletState::default()));
+        use_context_provider(|| Signal::new(NetworkInfo::default()));
+        use_context_provider(|| Signal::new(ConnectionState::default()));
+        use_context_provider(|| Signal::new(DevLog::default()));
+    }
+
+    /// Renders a component via SSR with all required context signals.
+    fn render_screen(screen: fn() -> Element) -> String {
+        let mut dom = VirtualDom::new(screen);
+        dom.rebuild_in_place();
+        dioxus_ssr::render(&dom)
+    }
+
+    // -- Wrapper components for each screen --
+    // Each provides context and delegates to the actual screen component.
+
+    fn send_wrapper() -> Element {
+        provide_test_contexts();
+        super::send::Send()
+    }
+
+    fn receive_wrapper() -> Element {
+        provide_test_contexts();
+        super::receive::Receive()
+    }
+
+    fn transactions_wrapper() -> Element {
+        provide_test_contexts();
+        super::transactions::Transactions()
+    }
+
+    fn settings_wrapper() -> Element {
+        provide_test_contexts();
+        super::settings::Settings()
+    }
+
+    fn dashboard_wrapper() -> Element {
+        provide_test_contexts();
+        super::dashboard::Dashboard()
+    }
+
+    /// Creates a routed wrapper that renders the screen at the given URL via
+    /// a `Router::<Route>` with a `MemoryHistory` starting at that path.
+    macro_rules! routed_wrapper {
+        ($name:ident, $url:expr) => {
+            fn $name() -> Element {
+                provide_test_contexts();
+                provide_history_context(Rc::new(MemoryHistory::with_initial_path($url)));
+                rsx! { Router::<Route> {} }
+            }
+        };
+    }
+
+    routed_wrapper!(network_select_routed, "/");
+    routed_wrapper!(wallet_choice_routed, "/wallet");
+    routed_wrapper!(wallet_create_routed, "/wallet/create");
+    routed_wrapper!(wallet_import_routed, "/wallet/import");
+
+    #[test]
+    fn send_screen_renders() {
+        let html = render_screen(send_wrapper);
+        assert!(html.contains("Send"), "expected 'Send' heading");
+        assert!(
+            html.contains("Destination Address"),
+            "expected address label"
+        );
+        assert!(html.contains("Amount"), "expected amount label");
+        assert!(html.contains("Fee Rate"), "expected fee rate label");
+        assert!(html.contains("Economy"), "expected economy fee option");
+        assert!(html.contains("Normal"), "expected normal fee option");
+        assert!(html.contains("Priority"), "expected priority fee option");
+        assert!(html.contains("Review"), "expected review button");
+    }
+
+    #[test]
+    fn receive_screen_renders() {
+        let html = render_screen(receive_wrapper);
+        assert!(html.contains("Receive"), "expected 'Receive' heading");
+        assert!(
+            html.contains("No address generated yet"),
+            "expected empty address placeholder"
+        );
+        assert!(
+            html.contains("Generate New Address"),
+            "expected generate button"
+        );
+    }
+
+    #[test]
+    fn transactions_screen_renders() {
+        let html = render_screen(transactions_wrapper);
+        assert!(
+            html.contains("Transactions"),
+            "expected 'Transactions' heading"
+        );
+        assert!(
+            html.contains("No transactions yet"),
+            "expected empty state message"
+        );
+        assert!(html.contains("All"), "expected 'All' filter tab");
+        assert!(html.contains("Received"), "expected 'Received' filter tab");
+        assert!(html.contains("Sent"), "expected 'Sent' filter tab");
+        assert!(
+            html.contains("Search by txid"),
+            "expected search placeholder"
+        );
+    }
+
+    #[test]
+    fn settings_screen_renders() {
+        let html = render_screen(settings_wrapper);
+        assert!(html.contains("Settings"), "expected 'Settings' heading");
+        assert!(html.contains("Network"), "expected network selector");
+        assert!(html.contains("Mainnet"), "expected mainnet option");
+        assert!(html.contains("Testnet"), "expected testnet option");
+        assert!(html.contains("Regtest"), "expected regtest option");
+        assert!(html.contains("Data Directory"), "expected data dir field");
+        assert!(html.contains("Log Level"), "expected log level selector");
+        assert!(html.contains("Save"), "expected save button");
+    }
+
+    #[test]
+    fn dashboard_screen_renders() {
+        let html = render_screen(dashboard_wrapper);
+        assert!(
+            html.contains("Available Balance"),
+            "expected balance heading"
+        );
+        assert!(
+            html.contains("No transactions yet"),
+            "expected empty tx message"
+        );
+    }
+
+    #[test]
+    fn network_select_screen_renders() {
+        let html = render_screen(network_select_routed);
+        assert!(html.contains("Dash SPV Wallet"), "expected app title");
+        assert!(html.contains("Select a network"), "expected subtitle");
+        assert!(html.contains("Mainnet"), "expected mainnet card");
+        assert!(html.contains("Testnet"), "expected testnet card");
+        assert!(html.contains("Regtest"), "expected regtest card");
+    }
+
+    #[test]
+    fn wallet_choice_screen_renders() {
+        let html = render_screen(wallet_choice_routed);
+        assert!(html.contains("Wallet Setup"), "expected heading");
+        assert!(html.contains("Create New Wallet"), "expected create option");
+        assert!(
+            html.contains("Import Existing Wallet"),
+            "expected import option"
+        );
+    }
+
+    #[test]
+    fn wallet_create_screen_renders() {
+        let html = render_screen(wallet_create_routed);
+        assert!(html.contains("Create New Wallet"), "expected heading");
+        assert!(html.contains("Generate"), "expected generate button text");
+    }
+
+    #[test]
+    fn wallet_import_screen_renders() {
+        let html = render_screen(wallet_import_routed);
+        assert!(html.contains("Import Wallet"), "expected heading");
+        assert!(
+            html.contains("recovery phrase"),
+            "expected recovery phrase text"
+        );
+        assert!(
+            html.contains("0 of 12 words"),
+            "expected word count display"
+        );
+    }
+}

--- a/src/screens/mod.rs
+++ b/src/screens/mod.rs
@@ -10,7 +10,7 @@ pub mod wallet_import;
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+
 
     use std::rc::Rc;
 
@@ -31,7 +31,7 @@ mod tests {
     fn test_config() -> AppConfig {
         AppConfig {
             network: Network::Testnet,
-            data_dir: PathBuf::from("/tmp/dash-spv-test"),
+            data_dir: std::env::temp_dir().join(format!("dash-spv-test-{}", std::process::id())),
             ..Default::default()
         }
     }

--- a/src/screens/mod.rs
+++ b/src/screens/mod.rs
@@ -11,7 +11,6 @@ pub mod wallet_import;
 #[cfg(test)]
 mod tests {
 
-
     use std::rc::Rc;
 
     use dioxus::prelude::*;


### PR DESCRIPTION
## Summary
- Move `screens`, `components`, `event_bridge`, `router`, and `state` modules from `main.rs` to `lib.rs` so tests can run with `--lib`
- Add `dioxus-ssr` and `dioxus-history` dev-dependencies for SSR rendering
- Add 10 SSR render tests covering all 9 screen components (dashboard, send, receive, transactions, settings, network_select, wallet_choice, wallet_create, wallet_import)

Closes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized module surface and imports for a cleaner public API layout.
  * Updated development dependencies used for testing and server-side rendering.

* **Tests**
  * Added server-side rendered UI tests for dashboard, send, receive, transactions, settings, and several routed entry points to improve stability and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->