### PR TITLE
fix: panic on missing dashd env vars instead of silently skipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libudev-dev libxdo-dev
       - run: npm install
       - run: cargo test --all-features
+        env:
+          SKIP_DASHD_TESTS: 1
 
   build:
     name: Build
@@ -104,6 +106,8 @@ jobs:
       - run: npm install
       - name: Generate coverage
         run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+        env:
+          SKIP_DASHD_TESTS: 1
       - uses: codecov/codecov-action@v5
         with:
           files: lcov.info

--- a/tests/dashd_sync/setup.rs
+++ b/tests/dashd_sync/setup.rs
@@ -13,9 +13,8 @@ pub struct BackendTestContext {
 impl BackendTestContext {
     /// Create a new test context for the given chain variant.
     ///
-    /// Returns `None` if dashd integration tests should be skipped (either
-    /// `SKIP_DASHD_TESTS` is set, required env vars are missing, or dashd
-    /// fails to start).
+    /// Returns `None` if `SKIP_DASHD_TESTS` is set. Panics if `DASHD_PATH`
+    /// or `DASHD_TEST_DATA` are missing or if dashd fails to start.
     pub async fn new(chain: TestChain) -> Option<Self> {
         if std::env::var("SKIP_DASHD_TESTS").is_ok() {
             eprintln!("Skipping: SKIP_DASHD_TESTS is set");
@@ -23,11 +22,11 @@ impl BackendTestContext {
         }
 
         if std::env::var("DASHD_PATH").is_err() || std::env::var("DASHD_TEST_DATA").is_err() {
-            eprintln!(
-                "Skipping: DASHD_PATH / DASHD_TEST_DATA not set. \
-                 Run `eval $(python3 contrib/setup-dashd.py)` to enable dashd tests."
+            panic!(
+                "DASHD_PATH and DASHD_TEST_DATA environment variables are required. \
+                 Run `eval $(python3 contrib/setup-dashd.py)` to set them, \
+                 or set SKIP_DASHD_TESTS=1 to skip these tests."
             );
-            return None;
         }
 
         // Spawn in a separate task so panics from dashd startup failures

--- a/tests/dashd_sync/setup.rs
+++ b/tests/dashd_sync/setup.rs
@@ -13,8 +13,8 @@ pub struct BackendTestContext {
 impl BackendTestContext {
     /// Create a new test context for the given chain variant.
     ///
-    /// Returns `None` if `SKIP_DASHD_TESTS` is set. Panics if `DASHD_PATH`
-    /// or `DASHD_TEST_DATA` are missing or if dashd fails to start.
+    /// Returns `None` if `SKIP_DASHD_TESTS` is set or if dashd fails to
+    /// start. Panics if `DASHD_PATH` or `DASHD_TEST_DATA` are missing.
     pub async fn new(chain: TestChain) -> Option<Self> {
         if std::env::var("SKIP_DASHD_TESTS").is_ok() {
             eprintln!("Skipping: SKIP_DASHD_TESTS is set");


### PR DESCRIPTION
## Summary
- `BackendTestContext::new()` now panics when `DASHD_PATH`/`DASHD_TEST_DATA` are missing instead of silently returning `None` (which caused tests to pass without actually running)
- `SKIP_DASHD_TESTS=1` must be set explicitly to opt out
- CI test/coverage jobs temporarily set `SKIP_DASHD_TESTS=1` until dashd setup is added in a follow-up PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to change which integration tests run during regular and coverage jobs for more consistent test runs.

* **Tests**
  * Test harness now fails loudly when required external tooling or test data are missing instead of silently skipping, improving diagnostics and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->