### PR TITLE
fix: restore event bridge and auto-start in `AppLayout`

### DIFF
--- a/src/components/layout.rs
+++ b/src/components/layout.rs
@@ -8,6 +8,8 @@ use crate::components::dev_panel::DevPanel;
 use crate::components::sidebar::Sidebar;
 use crate::components::status_bar::StatusBar;
 use crate::config::AppConfig;
+use crate::event_bridge::use_event_bridge;
+use crate::state::wallet::WalletState;
 
 #[component]
 pub fn AppLayout() -> Element {
@@ -26,9 +28,38 @@ pub fn AppLayout() -> Element {
         }
     });
 
+    // Start the event bridge coroutine to pipe backend events into UI state.
+    use_event_bridge();
+
+    let backend = use_context::<Signal<Backend>>();
+    let wallet = use_context::<Signal<WalletState>>();
+
+    // Load persisted wallet and auto-connect if not already running.
+    use_future(move || async move {
+        let _ = backend.read().load_wallet().await;
+        if !backend.read().is_running() {
+            let _ = backend.read().start().await;
+        }
+    });
+
+    // Load persisted transactions and balance on first mount only.
+    use_future(move || {
+        let mut wallet_state = wallet;
+        async move {
+            if !wallet_state.read().transactions.is_empty() {
+                return;
+            }
+            if let Ok(txs) = backend.read().get_transactions() {
+                wallet_state.write().set_transactions(txs);
+            }
+            if let Ok(balance) = backend.read().get_balance() {
+                wallet_state.write().balance = balance;
+            }
+        }
+    });
+
     // Stop the backend and persist window size when the component unmounts (app close).
     let window = use_window();
-    let backend = use_context::<Signal<Backend>>();
     use_drop(move || {
         if backend.read().is_running() {
             let rt = tokio::runtime::Runtime::new().expect("failed to create shutdown runtime");

--- a/src/components/layout.rs
+++ b/src/components/layout.rs
@@ -106,3 +106,21 @@ pub fn AppLayout() -> Element {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn event_bridge_lives_in_layout_not_dashboard() {
+        let layout_src = include_str!("layout.rs");
+        let dashboard_src = include_str!("../screens/dashboard.rs");
+
+        assert!(
+            layout_src.contains("use_event_bridge"),
+            "use_event_bridge must be called in AppLayout (layout.rs) so events update on all screens"
+        );
+        assert!(
+            !dashboard_src.contains("use_event_bridge"),
+            "use_event_bridge must NOT be in Dashboard — it was moved to AppLayout to fix screen navigation event loss"
+        );
+    }
+}

--- a/src/screens/dashboard.rs
+++ b/src/screens/dashboard.rs
@@ -1,10 +1,7 @@
 use dioxus::prelude::*;
 
-use crate::backend::dispatch::Backend;
-use crate::backend::r#trait::SpvBackend;
 use crate::backend::types::TransactionDirection;
 use crate::config::AppConfig;
-use crate::event_bridge::use_event_bridge;
 use crate::router::Route;
 use crate::state::network::NetworkInfo;
 use crate::state::view_models::{
@@ -16,37 +13,9 @@ const DASHBOARD_TX_LIMIT: usize = 5;
 
 #[component]
 pub fn Dashboard() -> Element {
-    let backend = use_context::<Signal<Backend>>();
     let wallet = use_context::<Signal<WalletState>>();
     let network_info = use_context::<Signal<NetworkInfo>>();
     let config = use_context::<Signal<AppConfig>>();
-
-    // Start the event bridge coroutine to pipe backend events into UI state.
-    use_event_bridge();
-
-    // Load persisted wallet and auto-connect if not already running.
-    use_future(move || async move {
-        let _ = backend.read().load_wallet().await;
-        if !backend.read().is_running() {
-            let _ = backend.read().start().await;
-        }
-    });
-
-    // Load persisted transactions and balance on first mount only.
-    use_future(move || {
-        let mut wallet_state = wallet;
-        async move {
-            if !wallet_state.read().transactions.is_empty() {
-                return;
-            }
-            if let Ok(txs) = backend.read().get_transactions() {
-                wallet_state.write().set_transactions(txs);
-            }
-            if let Ok(balance) = backend.read().get_balance() {
-                wallet_state.write().balance = balance;
-            }
-        }
-    });
 
     let mut expanded_txid = use_signal(|| None::<dashcore::Txid>);
 


### PR DESCRIPTION
## Summary
- Move `use_event_bridge()`, wallet auto-start, and persisted tx/balance loading back from `Dashboard` to `AppLayout` — PR #74 accidentally reverted this
- Add structural regression test using `include_str!` to guard against this being moved back to Dashboard

Closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized wallet initialization to automatically load persisted data and start the backend when the app launches.
  * Simplified the dashboard component by centralizing backend management at the application layout level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->