### PR TITLE
ci: add ASAN and TSAN sanitizer workflow

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -1,0 +1,67 @@
+name: Sanitizer
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    paths:
+      - 'src/backend/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  asan:
+    name: Address Sanitizer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install Linux dependencies
+        run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libudev-dev libxdo-dev
+      - run: npm install
+
+      - name: Run tests with ASAN
+        env:
+          RUST_BACKTRACE: 1
+          RUSTFLAGS: "-Zsanitizer=address -Cdebuginfo=2 -Cforce-frame-pointers=yes"
+          ASAN_OPTIONS: "symbolize=1:allow_addr2line=1"
+          LSAN_OPTIONS: "fast_unwind_on_malloc=0"
+          SKIP_DASHD_TESTS: 1
+        run: cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu --all-features
+
+  tsan:
+    name: Thread Sanitizer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install Linux dependencies
+        run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libudev-dev libxdo-dev
+      - run: npm install
+
+      - name: Run tests with TSAN
+        env:
+          RUST_BACKTRACE: 1
+          RUSTFLAGS: "-Zsanitizer=thread -Cdebuginfo=2"
+          TSAN_OPTIONS: "second_deadlock_stack=1"
+          SKIP_DASHD_TESTS: 1
+        run: cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu --all-features


### PR DESCRIPTION
## Summary
- Add `.github/workflows/sanitizer.yml` with AddressSanitizer (ASAN) and ThreadSanitizer (TSAN) jobs
- Uses Rust nightly + `-Zbuild-std` for full sanitizer instrumentation
- Matches rust-dashcore's sanitizer workflow pattern
- Dashd tests skipped initially (`SKIP_DASHD_TESTS=1`) — can enable later

Closes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated testing workflow to detect memory and threading issues in the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->