### PR TITLE
fix: skip doc tests in sanitizer workflow to avoid ABI mismatch

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -41,7 +41,7 @@ jobs:
           ASAN_OPTIONS: "symbolize=1:allow_addr2line=1"
           LSAN_OPTIONS: "fast_unwind_on_malloc=0"
           SKIP_DASHD_TESTS: 1
-        run: cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu --all-features
+        run: cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu --all-features --lib --tests
 
   tsan:
     name: Thread Sanitizer
@@ -64,4 +64,4 @@ jobs:
           RUSTFLAGS: "-Zsanitizer=thread -Cdebuginfo=2"
           TSAN_OPTIONS: "second_deadlock_stack=1"
           SKIP_DASHD_TESTS: 1
-        run: cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu --all-features
+        run: cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu --all-features --lib --tests


### PR DESCRIPTION
## Summary
- Add `--lib --tests` to ASAN and TSAN test commands to skip doc tests
- Doc tests link against non-sanitized dependencies, causing 342 ABI mismatch errors
- Matches rust-dashcore's sanitizer workflow pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/testing workflow configuration to refine test execution scope.

---

**Note:** This release contains no user-facing changes. The update improves internal testing infrastructure only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->