### PR TITLE
ci: exclude `main.rs` and `router.rs` from coverage reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,3 +16,5 @@ ignore:
   - "**/tests/**"
   - "**/tests.rs"
   - "**/test_utils/**"
+  - "src/main.rs"
+  - "src/router.rs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         run: python contrib/setup-dashd.py >> "$GITHUB_ENV"
 
       - name: Generate coverage
-        run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+        run: cargo llvm-cov --all-features --lcov --output-path lcov.info --ignore-filename-regex 'main\.rs$|router\.rs$'
         env:
           DASHD_TEST_RETAIN_DIR: ${{ runner.temp }}/dashd-test-logs
 


### PR DESCRIPTION
## Summary
- Add `src/main.rs` and `src/router.rs` to `.codecov.yml` ignore list
- Add `--ignore-filename-regex` to `cargo llvm-cov` command in CI
- These files contain startup/routing code that cannot be unit tested

Closes #91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage reporting configuration to exclude specific source files from coverage calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->