### PR TITLE
test: fill coverage gaps in `AppConfig` and `Backend` dispatch

### DIFF
--- a/src/backend/dispatch.rs
+++ b/src/backend/dispatch.rs
@@ -300,4 +300,102 @@ mod tests {
         let event = rx.try_recv();
         assert!(event.is_ok());
     }
+
+    #[test]
+    fn dispatch_network_devnet() {
+        assert_eq!(mock_backend(Network::Devnet).network(), Network::Devnet);
+    }
+
+    #[tokio::test]
+    async fn dispatch_start_already_running() {
+        let backend = mock_backend(Network::Testnet);
+        backend.start().await.unwrap();
+        let err = backend.start().await.unwrap_err();
+        assert_eq!(err, BackendError::AlreadyRunning);
+    }
+
+    #[tokio::test]
+    async fn dispatch_stop_not_running() {
+        let backend = mock_backend(Network::Testnet);
+        let err = backend.stop().await.unwrap_err();
+        assert_eq!(err, BackendError::NotRunning);
+    }
+
+    #[test]
+    fn dispatch_operations_without_wallet() {
+        let backend = mock_backend(Network::Testnet);
+        assert_eq!(backend.get_balance().unwrap_err(), BackendError::NoWallet);
+        assert_eq!(
+            backend.get_receive_address().unwrap_err(),
+            BackendError::NoWallet,
+        );
+        assert_eq!(
+            backend.get_transactions().unwrap_err(),
+            BackendError::NoWallet,
+        );
+        assert_eq!(
+            backend.estimate_fee("addr", 100, 1000).unwrap_err(),
+            BackendError::NoWallet,
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_send_errors() {
+        let backend = mock_backend_with_wallet(Network::Testnet, 1_000_000);
+        backend.load_wallet().await.unwrap();
+
+        // Empty address
+        let err = backend.send("", 100, 1000).await.unwrap_err();
+        assert!(matches!(err, BackendError::InvalidAddress(_)));
+
+        // Insufficient funds
+        let err = backend.send("Xaddr", 2_000_000, 1000).await.unwrap_err();
+        assert!(matches!(err, BackendError::InsufficientFunds { .. }));
+    }
+
+    #[tokio::test]
+    async fn dispatch_create_wallet_invalid_mnemonic() {
+        let backend = mock_backend(Network::Testnet);
+        let err = backend.create_wallet("bad mnemonic").await.unwrap_err();
+        assert!(matches!(err, BackendError::InvalidMnemonic(_)));
+    }
+
+    #[tokio::test]
+    async fn dispatch_sync_progress_with_tip() {
+        let backend = Backend::Mock(
+            MockBackend::builder(Network::Testnet)
+                .with_tip_height(5000)
+                .build(),
+        );
+        backend.start().await.unwrap();
+
+        let progress = backend.sync_progress();
+        assert_eq!(progress.state(), SyncState::WaitForEvents);
+    }
+
+    #[tokio::test]
+    async fn dispatch_generate_mnemonic_is_12_words() {
+        let backend = mock_backend(Network::Regtest);
+        let mnemonic = backend.generate_mnemonic().unwrap();
+        assert_eq!(mnemonic.split_whitespace().count(), 12);
+
+        // Verify the mnemonic can be used to create a wallet through dispatch
+        backend.create_wallet(&mnemonic).await.unwrap();
+        assert!(backend.get_balance().is_ok());
+    }
+
+    #[tokio::test]
+    async fn dispatch_multiple_sends_update_state() {
+        let backend = mock_backend_with_wallet(Network::Testnet, 1_000_000);
+        backend.load_wallet().await.unwrap();
+
+        backend.send("Xaddr1", 100_000, 1000).await.unwrap();
+        backend.send("Xaddr2", 200_000, 1000).await.unwrap();
+
+        let balance = backend.get_balance().unwrap();
+        assert_eq!(balance.spendable(), 700_000);
+
+        let txs = backend.get_transactions().unwrap();
+        assert_eq!(txs.len(), 2);
+    }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -386,4 +386,118 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&tmp);
     }
+
+    #[test]
+    fn ensure_dirs_with_default_wallet_dir() {
+        let tmp = std::env::temp_dir().join("dash-spv-ui-test-ensure-dirs-default");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let config = AppConfig {
+            data_dir: tmp.join("data"),
+            wallet_dir: None,
+            ..Default::default()
+        };
+        config.ensure_dirs().unwrap();
+
+        assert!(config.data_dir.exists());
+        assert!(tmp.join("data").join("wallets").exists());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn save_writes_valid_toml() {
+        let tmp = std::env::temp_dir().join("dash-spv-ui-test-save");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let config = AppConfig {
+            network: Network::Regtest,
+            data_dir: PathBuf::from("/tmp/data"),
+            wallet_dir: Some(PathBuf::from("/tmp/wallets")),
+            dev_mode: true,
+            log_level: "debug".to_string(),
+            window_width: 800,
+            window_height: 600,
+            ..Default::default()
+        };
+
+        let path = tmp.join("config.toml");
+        let contents = toml::to_string_pretty(&config).unwrap();
+        std::fs::write(&path, &contents).unwrap();
+
+        let restored: AppConfig = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(restored.network, Network::Regtest);
+        assert!(restored.dev_mode);
+        assert_eq!(restored.log_level, "debug");
+        assert_eq!(restored.window_width, 800);
+        assert_eq!(restored.window_height, 600);
+        assert_eq!(restored.wallet_dir, Some(PathBuf::from("/tmp/wallets")));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn config_error_implements_std_error() {
+        let io_err = ConfigError::Io(io::Error::new(io::ErrorKind::PermissionDenied, "denied"));
+        let std_err: &dyn std::error::Error = &io_err;
+        assert!(std_err.source().is_none());
+
+        let parse_err = ConfigError::Parse("bad".to_string());
+        let std_err: &dyn std::error::Error = &parse_err;
+        assert!(std_err.source().is_none());
+    }
+
+    #[test]
+    fn config_error_debug() {
+        let io_err = ConfigError::Io(io::Error::new(io::ErrorKind::NotFound, "missing"));
+        let debug = format!("{io_err:?}");
+        assert!(debug.contains("Io"));
+
+        let parse_err = ConfigError::Parse("invalid".to_string());
+        let debug = format!("{parse_err:?}");
+        assert!(debug.contains("Parse"));
+        assert!(debug.contains("invalid"));
+    }
+
+    #[test]
+    fn default_config_backend_and_peers() {
+        let config = AppConfig::default();
+        assert!(!config.mock_mode);
+        assert_eq!(config.backend, "native");
+        assert!(config.peers.is_empty());
+    }
+
+    #[test]
+    fn all_networks_serialize_distinct() {
+        let networks = [
+            Network::Mainnet,
+            Network::Testnet,
+            Network::Devnet,
+            Network::Regtest,
+        ];
+        let mut serialized = std::collections::HashSet::new();
+        for network in &networks {
+            let config = AppConfig {
+                network: *network,
+                ..Default::default()
+            };
+            let toml_str = toml::to_string_pretty(&config).unwrap();
+            assert!(
+                serialized.insert(toml_str),
+                "duplicate serialization for {network:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn devnet_roundtrip() {
+        let config = AppConfig {
+            network: Network::Devnet,
+            ..Default::default()
+        };
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        let restored: AppConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(restored.network, Network::Devnet);
+    }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -407,10 +407,6 @@ mod tests {
 
     #[test]
     fn save_writes_valid_toml() {
-        let tmp = std::env::temp_dir().join("dash-spv-ui-test-save");
-        let _ = std::fs::remove_dir_all(&tmp);
-        std::fs::create_dir_all(&tmp).unwrap();
-
         let config = AppConfig {
             network: Network::Regtest,
             data_dir: PathBuf::from("/tmp/data"),
@@ -422,10 +418,9 @@ mod tests {
             ..Default::default()
         };
 
-        let path = tmp.join("config.toml");
-        let contents = toml::to_string_pretty(&config).unwrap();
-        std::fs::write(&path, &contents).unwrap();
+        config.save().unwrap();
 
+        let path = paths::config_file_path();
         let restored: AppConfig = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(restored.network, Network::Regtest);
         assert!(restored.dev_mode);
@@ -433,8 +428,6 @@ mod tests {
         assert_eq!(restored.window_width, 800);
         assert_eq!(restored.window_height, 600);
         assert_eq!(restored.wallet_dir, Some(PathBuf::from("/tmp/wallets")));
-
-        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add 7 tests for `AppConfig`: wallet_dir fallback, save round-trip, ConfigError impls, Devnet serialization, default skip fields
- Add 8 tests for `Backend` dispatch: error paths (AlreadyRunning, NotRunning, NoWallet, InvalidAddress, InsufficientFunds, InvalidMnemonic), Devnet network, cumulative send state

Closes #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Expanded test coverage for backend dispatch operations, including error handling, wallet operations, and network configuration.
* Enhanced configuration management tests for directory creation, TOML serialization, and default settings validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->