### PR TITLE
refactor: extract testable logic from screen components and add tests

### DIFF
--- a/src/screens/network_select.rs
+++ b/src/screens/network_select.rs
@@ -69,6 +69,24 @@ pub fn NetworkSelect() -> Element {
     }
 }
 
+fn border_class_for_color(color: &str) -> &'static str {
+    match color {
+        "blue" => "border-dash hover:bg-dash/10",
+        "green" => "border-success hover:bg-success/10",
+        "orange" => "border-warning hover:bg-warning/10",
+        _ => "border-edge hover:bg-hover",
+    }
+}
+
+fn dot_class_for_color(color: &str) -> &'static str {
+    match color {
+        "blue" => "bg-dash",
+        "green" => "bg-success",
+        "orange" => "bg-warning",
+        _ => "bg-muted",
+    }
+}
+
 #[component]
 fn NetworkCard(
     name: &'static str,
@@ -76,19 +94,8 @@ fn NetworkCard(
     color: &'static str,
     onclick: EventHandler<MouseEvent>,
 ) -> Element {
-    let border_class = match color {
-        "blue" => "border-dash hover:bg-dash/10",
-        "green" => "border-success hover:bg-success/10",
-        "orange" => "border-warning hover:bg-warning/10",
-        _ => "border-edge hover:bg-hover",
-    };
-
-    let dot_class = match color {
-        "blue" => "bg-dash",
-        "green" => "bg-success",
-        "orange" => "bg-warning",
-        _ => "bg-muted",
-    };
+    let border_class = border_class_for_color(color);
+    let dot_class = dot_class_for_color(color);
 
     rsx! {
         div {
@@ -107,5 +114,44 @@ fn NetworkCard(
                 "{description}"
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn border_class_known_colors() {
+        assert_eq!(
+            border_class_for_color("blue"),
+            "border-dash hover:bg-dash/10"
+        );
+        assert_eq!(
+            border_class_for_color("green"),
+            "border-success hover:bg-success/10"
+        );
+        assert_eq!(
+            border_class_for_color("orange"),
+            "border-warning hover:bg-warning/10"
+        );
+    }
+
+    #[test]
+    fn border_class_unknown_color() {
+        assert_eq!(border_class_for_color("red"), "border-edge hover:bg-hover");
+        assert_eq!(border_class_for_color(""), "border-edge hover:bg-hover");
+    }
+
+    #[test]
+    fn dot_class_known_colors() {
+        assert_eq!(dot_class_for_color("blue"), "bg-dash");
+        assert_eq!(dot_class_for_color("green"), "bg-success");
+        assert_eq!(dot_class_for_color("orange"), "bg-warning");
+    }
+
+    #[test]
+    fn dot_class_unknown_color() {
+        assert_eq!(dot_class_for_color("red"), "bg-muted");
     }
 }

--- a/src/screens/send.rs
+++ b/src/screens/send.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
-use dashcore::Address as DashAddress;
 use dashcore::address::NetworkUnchecked;
+use dashcore::{Address as DashAddress, Network};
 use dioxus::prelude::*;
 
 use crate::backend::dispatch::Backend;
@@ -54,6 +54,42 @@ impl FeeRate {
     const ALL: [FeeRate; 3] = [FeeRate::Economy, FeeRate::Normal, FeeRate::Priority];
 }
 
+/// Validate a Dash address string for a given network.
+fn validate_send_address(address: &str, network: Network) -> Result<(), String> {
+    let trimmed = address.trim();
+    if trimmed.is_empty() {
+        return Err("Address is required".to_string());
+    }
+    let unchecked = DashAddress::<NetworkUnchecked>::from_str(trimmed)
+        .map_err(|_| "Invalid address format".to_string())?;
+    if !unchecked.is_valid_for_network(network) {
+        return Err("Address is for a different network".to_string());
+    }
+    Ok(())
+}
+
+/// Validate a send amount against the spendable balance.
+fn validate_send_amount(amount_str: &str, spendable: u64) -> Result<u64, String> {
+    match parse_dash_amount(amount_str) {
+        None => Err("Invalid amount".to_string()),
+        Some(0) => Err("Amount must be greater than 0".to_string()),
+        Some(sats) if sats > spendable => Err("Exceeds spendable balance".to_string()),
+        Some(sats) => Ok(sats),
+    }
+}
+
+/// Format a satoshi amount as a user-friendly DASH string for the "Max" button.
+fn format_max_amount(sats: u64) -> String {
+    let whole = sats / 100_000_000;
+    let frac = sats % 100_000_000;
+    if frac == 0 {
+        format!("{whole}")
+    } else {
+        let frac_str = format!("{frac:08}").trim_end_matches('0').to_string();
+        format!("{whole}.{frac_str}")
+    }
+}
+
 #[component]
 pub fn Send() -> Element {
     let backend = use_context::<Signal<Backend>>();
@@ -73,43 +109,20 @@ pub fn Send() -> Element {
     let mut validate_form = move || -> bool {
         let mut valid = true;
 
-        let addr_str = address.read().clone();
-        if addr_str.trim().is_empty() {
-            address_error.set(Some("Address is required".to_string()));
-            valid = false;
-        } else {
-            match DashAddress::<NetworkUnchecked>::from_str(addr_str.trim()) {
-                Err(_) => {
-                    address_error.set(Some("Invalid address format".to_string()));
-                    valid = false;
-                }
-                Ok(unchecked) => {
-                    let network = config.read().network;
-                    if !unchecked.is_valid_for_network(network) {
-                        address_error.set(Some("Address is for a different network".to_string()));
-                        valid = false;
-                    } else {
-                        address_error.set(None);
-                    }
-                }
+        let network = config.read().network;
+        match validate_send_address(&address.read(), network) {
+            Ok(()) => address_error.set(None),
+            Err(e) => {
+                address_error.set(Some(e));
+                valid = false;
             }
         }
 
-        match parse_dash_amount(&amount_str.read()) {
-            None => {
-                amount_error.set(Some("Invalid amount".to_string()));
+        match validate_send_amount(&amount_str.read(), spendable) {
+            Ok(_) => amount_error.set(None),
+            Err(e) => {
+                amount_error.set(Some(e));
                 valid = false;
-            }
-            Some(0) => {
-                amount_error.set(Some("Amount must be greater than 0".to_string()));
-                valid = false;
-            }
-            Some(sats) if sats > spendable => {
-                amount_error.set(Some("Exceeds spendable balance".to_string()));
-                valid = false;
-            }
-            Some(_) => {
-                amount_error.set(None);
             }
         }
 
@@ -198,15 +211,7 @@ pub fn Send() -> Element {
                                 button {
                                     class: "absolute right-2 top-1/2 -translate-y-1/2 bg-hover hover:bg-edge text-muted text-xs px-3 py-1 rounded transition-colors",
                                     onclick: move |_| {
-                                        let whole = spendable / 100_000_000;
-                                        let frac = spendable % 100_000_000;
-                                        let s = if frac == 0 {
-                                            format!("{whole}")
-                                        } else {
-                                            let frac_str = format!("{frac:08}").trim_end_matches('0').to_string();
-                                            format!("{whole}.{frac_str}")
-                                        };
-                                        amount_str.set(s);
+                                        amount_str.set(format_max_amount(spendable));
                                         amount_error.set(None);
                                     },
                                     "Max"
@@ -494,5 +499,148 @@ pub fn Send() -> Element {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dashcore::PublicKey;
+
+    use super::*;
+
+    fn test_address(network: Network) -> String {
+        let pk = PublicKey::from_slice(&[
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x01,
+        ])
+        .unwrap();
+        DashAddress::p2pkh(&pk, network).to_string()
+    }
+
+    // -- validate_send_address --
+
+    #[test]
+    fn validate_send_address_empty() {
+        let err = validate_send_address("", Network::Testnet).unwrap_err();
+        assert_eq!(err, "Address is required");
+    }
+
+    #[test]
+    fn validate_send_address_whitespace_only() {
+        let err = validate_send_address("   ", Network::Testnet).unwrap_err();
+        assert_eq!(err, "Address is required");
+    }
+
+    #[test]
+    fn validate_send_address_invalid_format() {
+        let err = validate_send_address("not-an-address", Network::Testnet).unwrap_err();
+        assert_eq!(err, "Invalid address format");
+    }
+
+    #[test]
+    fn validate_send_address_wrong_network() {
+        let testnet_addr = test_address(Network::Testnet);
+        let err = validate_send_address(&testnet_addr, Network::Mainnet).unwrap_err();
+        assert_eq!(err, "Address is for a different network");
+    }
+
+    #[test]
+    fn validate_send_address_valid_testnet() {
+        let addr = test_address(Network::Testnet);
+        assert!(validate_send_address(&addr, Network::Testnet).is_ok());
+    }
+
+    #[test]
+    fn validate_send_address_valid_mainnet() {
+        let addr = test_address(Network::Mainnet);
+        assert!(validate_send_address(&addr, Network::Mainnet).is_ok());
+    }
+
+    // -- validate_send_amount --
+
+    #[test]
+    fn validate_send_amount_valid() {
+        assert_eq!(validate_send_amount("1.5", 200_000_000), Ok(150_000_000));
+    }
+
+    #[test]
+    fn validate_send_amount_invalid_input() {
+        assert_eq!(
+            validate_send_amount("abc", 100_000_000),
+            Err("Invalid amount".to_string())
+        );
+    }
+
+    #[test]
+    fn validate_send_amount_zero() {
+        assert_eq!(
+            validate_send_amount("0", 100_000_000),
+            Err("Amount must be greater than 0".to_string())
+        );
+    }
+
+    #[test]
+    fn validate_send_amount_exceeds_balance() {
+        assert_eq!(
+            validate_send_amount("2", 100_000_000),
+            Err("Exceeds spendable balance".to_string())
+        );
+    }
+
+    #[test]
+    fn validate_send_amount_exact_balance() {
+        assert_eq!(validate_send_amount("1", 100_000_000), Ok(100_000_000));
+    }
+
+    #[test]
+    fn validate_send_amount_empty() {
+        assert_eq!(
+            validate_send_amount("", 100_000_000),
+            Err("Invalid amount".to_string())
+        );
+    }
+
+    // -- format_max_amount --
+
+    #[test]
+    fn format_max_amount_zero() {
+        assert_eq!(format_max_amount(0), "0");
+    }
+
+    #[test]
+    fn format_max_amount_whole() {
+        assert_eq!(format_max_amount(100_000_000), "1");
+    }
+
+    #[test]
+    fn format_max_amount_with_fraction() {
+        assert_eq!(format_max_amount(150_000_000), "1.5");
+    }
+
+    #[test]
+    fn format_max_amount_one_satoshi() {
+        assert_eq!(format_max_amount(1), "0.00000001");
+    }
+
+    #[test]
+    fn format_max_amount_trailing_zeros_stripped() {
+        assert_eq!(format_max_amount(123_400_000), "1.234");
+    }
+
+    // -- FeeRate --
+
+    #[test]
+    fn fee_rate_labels() {
+        assert_eq!(FeeRate::Economy.label(), "Economy");
+        assert_eq!(FeeRate::Normal.label(), "Normal");
+        assert_eq!(FeeRate::Priority.label(), "Priority");
+    }
+
+    #[test]
+    fn fee_rate_sat_per_kb() {
+        assert_eq!(FeeRate::Economy.sat_per_kb(), 1_000);
+        assert_eq!(FeeRate::Normal.sat_per_kb(), 10_000);
+        assert_eq!(FeeRate::Priority.sat_per_kb(), 100_000);
     }
 }

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -309,3 +309,115 @@ pub fn Transactions() -> Element {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use dashcore::hashes::Hash;
+
+    use super::*;
+
+    fn sample_txs() -> Vec<TransactionInfo> {
+        vec![
+            TransactionInfo {
+                txid: dashcore::Txid::from_byte_array([0xAA; 32]),
+                amount: 100_000_000,
+                direction: TransactionDirection::Received,
+                timestamp: 1700000000,
+                height: Some(100),
+                fee: None,
+                addresses: vec!["yAddr1".into()],
+                block_hash: None,
+                is_instant_send: false,
+                is_chain_locked: false,
+            },
+            TransactionInfo {
+                txid: dashcore::Txid::from_byte_array([0xBB; 32]),
+                amount: -50_000_000,
+                direction: TransactionDirection::Sent,
+                timestamp: 1700001000,
+                height: Some(101),
+                fee: Some(226),
+                addresses: vec!["yAddr2".into()],
+                block_hash: None,
+                is_instant_send: false,
+                is_chain_locked: false,
+            },
+            TransactionInfo {
+                txid: dashcore::Txid::from_byte_array([0xCC; 32]),
+                amount: 200_000_000,
+                direction: TransactionDirection::Received,
+                timestamp: 1700002000,
+                height: Some(102),
+                fee: None,
+                addresses: vec!["yAddr3".into()],
+                block_hash: None,
+                is_instant_send: true,
+                is_chain_locked: false,
+            },
+        ]
+    }
+
+    #[test]
+    fn apply_filters_all() {
+        let txs = sample_txs();
+        let result = apply_filters(&txs, TxFilter::All, "", "DASH");
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn apply_filters_received_only() {
+        let txs = sample_txs();
+        let result = apply_filters(&txs, TxFilter::Received, "", "DASH");
+        assert_eq!(result.len(), 2);
+        assert!(
+            result
+                .iter()
+                .all(|tx| tx.direction == TransactionDirection::Received)
+        );
+    }
+
+    #[test]
+    fn apply_filters_sent_only() {
+        let txs = sample_txs();
+        let result = apply_filters(&txs, TxFilter::Sent, "", "DASH");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].direction, TransactionDirection::Sent);
+    }
+
+    #[test]
+    fn apply_filters_with_search() {
+        let txs = sample_txs();
+        let result = apply_filters(&txs, TxFilter::All, "yAddr2", "DASH");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].addresses[0], "yAddr2");
+    }
+
+    #[test]
+    fn apply_filters_no_match() {
+        let txs = sample_txs();
+        let result = apply_filters(&txs, TxFilter::All, "zzz_nonexistent", "DASH");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn apply_filters_combined_filter_and_search() {
+        let txs = sample_txs();
+        let result = apply_filters(&txs, TxFilter::Received, "yAddr3", "DASH");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].addresses[0], "yAddr3");
+    }
+
+    #[test]
+    fn apply_filters_empty_transactions() {
+        let txs: Vec<TransactionInfo> = vec![];
+        let result = apply_filters(&txs, TxFilter::All, "", "DASH");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn tx_filter_labels() {
+        assert_eq!(TxFilter::All.label(), "All");
+        assert_eq!(TxFilter::Received.label(), "Received");
+        assert_eq!(TxFilter::Sent.label(), "Sent");
+    }
+}

--- a/src/screens/wallet_import.rs
+++ b/src/screens/wallet_import.rs
@@ -5,6 +5,21 @@ use crate::backend::r#trait::SpvBackend;
 use crate::router::Route;
 use crate::state::app_state::AppState;
 
+/// Count the number of whitespace-separated words in a mnemonic input.
+fn mnemonic_word_count(input: &str) -> usize {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        0
+    } else {
+        trimmed.split_whitespace().count()
+    }
+}
+
+/// Check whether a word count is valid for a BIP-39 mnemonic (12 or 24 words).
+fn is_valid_mnemonic_word_count(count: usize) -> bool {
+    count == 12 || count == 24
+}
+
 #[component]
 pub fn WalletImport() -> Element {
     let mut app_state = use_context::<Signal<AppState>>();
@@ -15,17 +30,8 @@ pub fn WalletImport() -> Element {
     let mut error_message = use_signal(|| None::<String>);
     let mut is_importing = use_signal(|| false);
 
-    let word_count = {
-        let input = mnemonic_input.read();
-        let trimmed = input.trim();
-        if trimmed.is_empty() {
-            0
-        } else {
-            trimmed.split_whitespace().count()
-        }
-    };
-
-    let is_valid_count = word_count == 12 || word_count == 24;
+    let word_count = mnemonic_word_count(&mnemonic_input.read());
+    let is_valid_count = is_valid_mnemonic_word_count(word_count);
 
     let import_wallet = move |_| async move {
         if *is_importing.read() {
@@ -103,5 +109,57 @@ pub fn WalletImport() -> Element {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- mnemonic_word_count --
+
+    #[test]
+    fn mnemonic_word_count_empty() {
+        assert_eq!(mnemonic_word_count(""), 0);
+    }
+
+    #[test]
+    fn mnemonic_word_count_whitespace_only() {
+        assert_eq!(mnemonic_word_count("   \t  \n  "), 0);
+    }
+
+    #[test]
+    fn mnemonic_word_count_twelve_words() {
+        let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        assert_eq!(mnemonic_word_count(phrase), 12);
+    }
+
+    #[test]
+    fn mnemonic_word_count_extra_spaces() {
+        let phrase = "  word1  word2   word3  ";
+        assert_eq!(mnemonic_word_count(phrase), 3);
+    }
+
+    #[test]
+    fn mnemonic_word_count_single_word() {
+        assert_eq!(mnemonic_word_count("abandon"), 1);
+    }
+
+    // -- is_valid_mnemonic_word_count --
+
+    #[test]
+    fn valid_mnemonic_word_counts() {
+        assert!(is_valid_mnemonic_word_count(12));
+        assert!(is_valid_mnemonic_word_count(24));
+    }
+
+    #[test]
+    fn invalid_mnemonic_word_counts() {
+        assert!(!is_valid_mnemonic_word_count(0));
+        assert!(!is_valid_mnemonic_word_count(1));
+        assert!(!is_valid_mnemonic_word_count(11));
+        assert!(!is_valid_mnemonic_word_count(13));
+        assert!(!is_valid_mnemonic_word_count(23));
+        assert!(!is_valid_mnemonic_word_count(25));
     }
 }


### PR DESCRIPTION
## Summary
- Extract `validate_send_address`, `validate_send_amount`, `format_max_amount` from send.rs RSX closures + 16 tests
- Extract `mnemonic_word_count`, `is_valid_mnemonic_word_count` from wallet_import.rs + 7 tests
- Add 8 tests for existing `apply_filters` in transactions.rs
- Extract `border_class_for_color`, `dot_class_for_color` from network_select.rs + 4 tests

Closes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for network selection, send form validation, transaction filtering, and wallet import functionality.

* **Refactor**
  * Improved internal code organization and modularity across network, send, and wallet import screens for enhanced maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->