### PR TITLE
fix: replace unsupported Mermaid `block-beta` with `graph TD`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,16 @@ Dash SPV Wallet is a cross-platform desktop wallet built with [Dioxus](https://d
 ## Architecture
 
 ```mermaid
-block-beta
-  columns 1
-  block:ui["Dioxus Components (RSX + Tailwind CSS)"]
-  end
-  block:vm["View Models / State"]
-  end
-  block:trait["SpvBackend trait"]
-  end
-  block:backends
-    columns 2
-    native["NativeBackend\n(dash-spv)"]
-    ffi["FfiBackend\n(dash-spv-ffi)"]
-  end
+graph TD
+    UI["Dioxus Components<br/>(RSX + Tailwind CSS)"]
+    VM["View Models / State"]
+    Trait["SpvBackend trait"]
+    Native["NativeBackend<br/>(dash-spv)"]
+    FFI["FfiBackend<br/>(dash-spv-ffi)"]
+
+    UI --> VM --> Trait
+    Trait --> Native
+    Trait --> FFI
 ```
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
- Replace `block-beta` Mermaid syntax (unsupported by GitHub) with `graph TD` flowchart
- Architecture diagram now renders correctly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the Architecture diagram in the README with improved formatting and explicitly defined component relationships for clearer visualization of the system structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->