### PR TITLE
feat: add mempool strategy setting

### DIFF
--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -10,7 +10,7 @@ use dash_spv::network::NetworkEvent;
 use dash_spv::network::manager::PeerNetworkManager;
 use dash_spv::storage::DiskStorageManager;
 use dash_spv::sync::SyncEvent;
-use dash_spv::{ClientConfig, DashSpvClient};
+use dash_spv::{ClientConfig, DashSpvClient, MempoolStrategy};
 use dashcore::hashes::Hash;
 use key_wallet::managed_account::managed_account_type::ManagedAccountType;
 use key_wallet::mnemonic::Language;
@@ -122,6 +122,12 @@ impl SpvBackend for NativeBackend {
             }
             client_config = client_config.with_restrict_to_configured_peers(true);
         }
+
+        let mempool_strategy = match self.config.mempool_strategy.as_str() {
+            "fetch-all" => MempoolStrategy::FetchAll,
+            _ => MempoolStrategy::BloomFilter,
+        };
+        client_config = client_config.with_mempool_tracking(mempool_strategy);
 
         let network_manager = PeerNetworkManager::new(&client_config)
             .await

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -106,6 +106,15 @@ impl AppConfig {
             config.mempool_strategy = mempool_strategy;
         }
 
+        // Validate mempool strategy.
+        let valid_strategies = ["bloom-filter", "fetch-all"];
+        if !valid_strategies.contains(&config.mempool_strategy.as_str()) {
+            return Err(ConfigError::Parse(format!(
+                "invalid mempool_strategy '{}': must be 'bloom-filter' or 'fetch-all'",
+                config.mempool_strategy
+            )));
+        }
+
         // Expand tilde in paths.
         config.data_dir = paths::expand_tilde(&config.data_dir);
         if let Some(ref dir) = config.wallet_dir {
@@ -553,5 +562,23 @@ mod tests {
             let restored: AppConfig = toml::from_str(&toml_str).unwrap();
             assert_eq!(restored.mempool_strategy, strategy);
         }
+    }
+
+    #[test]
+    fn invalid_mempool_strategy_is_rejected() {
+        let toml_str = r#"
+            network = "testnet"
+            data_dir = "/tmp"
+            dev_mode = false
+            log_level = "info"
+            mempool_strategy = "invalid-strategy"
+        "#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.mempool_strategy, "invalid-strategy");
+
+        // Validation happens in `AppConfig::load()` which parses CLI args,
+        // so we test the validation logic directly here.
+        let valid_strategies = ["bloom-filter", "fetch-all"];
+        assert!(!valid_strategies.contains(&config.mempool_strategy.as_str()));
     }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -30,6 +30,9 @@ pub struct AppConfig {
     /// When non-empty, the SPV client connects exclusively to these peers.
     #[serde(default)]
     pub peers: Vec<String>,
+    /// Mempool strategy: "fetch-all" or "bloom-filter".
+    #[serde(default = "default_mempool_strategy")]
+    pub mempool_strategy: String,
 }
 
 fn default_window_width() -> u32 {
@@ -38,6 +41,10 @@ fn default_window_width() -> u32 {
 
 fn default_window_height() -> u32 {
     768
+}
+
+fn default_mempool_strategy() -> String {
+    "bloom-filter".to_string()
 }
 
 impl Default for AppConfig {
@@ -53,6 +60,7 @@ impl Default for AppConfig {
             mock_mode: false,
             backend: "native".to_string(),
             peers: Vec::new(),
+            mempool_strategy: default_mempool_strategy(),
         }
     }
 }
@@ -93,6 +101,9 @@ impl AppConfig {
         }
         if !cli.peer.is_empty() {
             config.peers = cli.peer;
+        }
+        if let Some(mempool_strategy) = cli.mempool_strategy {
+            config.mempool_strategy = mempool_strategy;
         }
 
         // Expand tilde in paths.
@@ -160,6 +171,10 @@ struct Cli {
     /// Explicit peer addresses (e.g., --peer 1.2.3.4:19999)
     #[arg(long)]
     peer: Vec<String>,
+
+    /// Mempool strategy: "fetch-all" or "bloom-filter"
+    #[arg(long)]
+    mempool_strategy: Option<String>,
 }
 
 /// Errors that can occur during configuration loading or saving.
@@ -192,6 +207,7 @@ mod tests {
         assert_eq!(config.log_level, "info");
         assert!(config.wallet_dir.is_none());
         assert!(config.data_dir.components().count() > 0);
+        assert_eq!(config.mempool_strategy, "bloom-filter");
     }
 
     #[test]
@@ -213,6 +229,7 @@ mod tests {
         assert_eq!(restored.wallet_dir, config.wallet_dir);
         assert_eq!(restored.dev_mode, config.dev_mode);
         assert_eq!(restored.log_level, config.log_level);
+        assert_eq!(restored.mempool_strategy, config.mempool_strategy);
     }
 
     #[test]
@@ -387,6 +404,7 @@ mod tests {
         assert_eq!(config.network, Network::Mainnet);
         assert!(config.wallet_dir.is_none());
         assert_eq!(config.window_width, 1024);
+        assert_eq!(config.mempool_strategy, "bloom-filter");
     }
 
     #[test]
@@ -522,5 +540,18 @@ mod tests {
         let toml_str = toml::to_string_pretty(&config).unwrap();
         let restored: AppConfig = toml::from_str(&toml_str).unwrap();
         assert_eq!(restored.network, Network::Devnet);
+    }
+
+    #[test]
+    fn mempool_strategy_roundtrip() {
+        for strategy in ["bloom-filter", "fetch-all"] {
+            let config = AppConfig {
+                mempool_strategy: strategy.to_string(),
+                ..Default::default()
+            };
+            let toml_str = toml::to_string_pretty(&config).unwrap();
+            let restored: AppConfig = toml::from_str(&toml_str).unwrap();
+            assert_eq!(restored.mempool_strategy, strategy);
+        }
     }
 }

--- a/src/screens/settings.rs
+++ b/src/screens/settings.rs
@@ -13,6 +13,9 @@ const NETWORKS: &[(&str, dashcore::Network)] = &[
 
 const LOG_LEVELS: &[&str] = &["error", "warn", "info", "debug", "trace"];
 
+const MEMPOOL_STRATEGIES: &[(&str, &str)] =
+    &[("Bloom Filter", "bloom-filter"), ("Fetch All", "fetch-all")];
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ClearCacheState {
     Idle,
@@ -58,6 +61,7 @@ pub fn Settings() -> Element {
     let mut network = use_signal(|| config.network);
     let mut dev_mode = use_signal(|| config.dev_mode);
     let mut log_level = use_signal(|| config.log_level.clone());
+    let mut mempool_strategy = use_signal(|| config.mempool_strategy.clone());
 
     let backends: &[&str] = if cfg!(feature = "ffi") {
         &["native", "ffi"]
@@ -77,6 +81,7 @@ pub fn Settings() -> Element {
         };
         cfg.dev_mode = dev_mode();
         cfg.log_level = log_level();
+        cfg.mempool_strategy = mempool_strategy();
 
         match cfg.save() {
             Ok(()) => save_status.set(Some(Ok(()))),
@@ -190,6 +195,32 @@ pub fn Settings() -> Element {
                                 "{level}"
                             }
                         }
+                    }
+                }
+
+                // Mempool strategy selector
+                div {
+                    label {
+                        class: "block text-muted text-sm uppercase tracking-wide mb-2",
+                        "Mempool Strategy"
+                    }
+                    div {
+                        class: "flex gap-2",
+                        for &(label, value) in MEMPOOL_STRATEGIES {
+                            button {
+                                class: if mempool_strategy() == value {
+                                    "px-3 py-1 rounded-lg bg-dash text-foreground text-sm font-medium"
+                                } else {
+                                    "px-3 py-1 rounded-lg bg-surface-alt text-muted text-sm hover:bg-hover transition-colors"
+                                },
+                                onclick: move |_| mempool_strategy.set(value.to_string()),
+                                "{label}"
+                            }
+                        }
+                    }
+                    p {
+                        class: "text-muted text-xs mt-1",
+                        "Requires restart."
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Add `mempool_strategy` config field (persisted in TOML, defaults to `bloom-filter`)
- Add `--mempool-strategy` CLI argument (`bloom-filter` or `fetch-all`)
- Add button-group selector in Settings screen with "Requires restart" note
- Wire to `ClientConfig::with_mempool_tracking()` in NativeBackend

Closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable mempool strategy with two options: "Bloom Filter" (default) and "Fetch All"
  * New selector in Settings to choose mempool strategy (selection saved; requires restart)
  * CLI override available via --mempool-strategy
  * Validation added to reject invalid mempool strategy values
<!-- end of auto-generated comment: release notes by coderabbit.ai -->