### PR TITLE
refactor: store SPV chain data in network-specific subdirectory

### DIFF
--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1006,25 +1006,9 @@ impl SpvBackend for FfiBackend {
             self.stop().await?;
         }
 
-        let network_dir = self.config.network_data_dir();
-        let wallet_dir = self.config.wallet_dir();
-        if wallet_dir.starts_with(&network_dir) {
-            return Err(BackendError::Storage(
-                "wallet dir is inside network data dir; refusing to clear cache".to_string(),
-            ));
-        }
-
-        if network_dir.exists() {
-            std::fs::remove_dir_all(&network_dir).map_err(|e| {
-                BackendError::Storage(format!("failed to remove {}: {e}", network_dir.display()))
-            })?;
-        }
-
-        std::fs::create_dir_all(&network_dir).map_err(|e| {
-            BackendError::Storage(format!("failed to recreate {}: {e}", network_dir.display()))
-        })?;
-
-        Ok(())
+        self.config
+            .clear_network_data_dir()
+            .map_err(|e| BackendError::Storage(e.to_string()))
     }
 
     fn subscribe_events(&self) -> EventReceiver {

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -138,7 +138,7 @@ impl SpvBackend for FfiBackend {
 
         let app_network = self.config.network;
         let network = network_to_ffi(app_network);
-        let data_dir = self.config.data_dir.display().to_string();
+        let data_dir = self.config.network_data_dir().display().to_string();
         let peers = self.config.peers.clone();
         let event_tx = self.event_tx.clone();
         let progress = self.progress.clone();
@@ -998,10 +998,7 @@ impl SpvBackend for FfiBackend {
     }
 
     fn cache_size(&self) -> BackendResult<u64> {
-        Ok(super::dir_size_excluding(
-            &self.config.data_dir,
-            Some(&self.config.wallet_dir()),
-        ))
+        Ok(super::dir_size(&self.config.network_data_dir()))
     }
 
     async fn clear_cache(&self) -> BackendResult<()> {
@@ -1009,32 +1006,11 @@ impl SpvBackend for FfiBackend {
             self.stop().await?;
         }
 
-        let data_dir = &self.config.data_dir;
-        let wallet_dir = self.config.wallet_dir();
-
-        let entries = std::fs::read_dir(data_dir)
-            .map_err(|e| BackendError::Storage(format!("failed to read data dir: {e}")))?;
-
-        for entry in entries.flatten() {
-            let path = entry.path();
-
-            // Skip if this path is or contains the wallet directory
-            if wallet_dir.starts_with(&path) || path.starts_with(&wallet_dir) {
-                continue;
-            }
-
-            // Skip config file
-            if path.file_name().is_some_and(|n| n == "config.toml") {
-                continue;
-            }
-
-            if path.is_dir() {
-                if let Err(e) = std::fs::remove_dir_all(&path) {
-                    tracing::warn!("Failed to remove cache dir {}: {e}", path.display());
-                }
-            } else if let Err(e) = std::fs::remove_file(&path) {
-                tracing::warn!("Failed to remove cache file {}: {e}", path.display());
-            }
+        let network_dir = self.config.network_data_dir();
+        if network_dir.exists() {
+            std::fs::remove_dir_all(&network_dir).map_err(|e| {
+                BackendError::Storage(format!("failed to remove {}: {e}", network_dir.display()))
+            })?;
         }
 
         Ok(())

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1007,11 +1007,22 @@ impl SpvBackend for FfiBackend {
         }
 
         let network_dir = self.config.network_data_dir();
+        let wallet_dir = self.config.wallet_dir();
+        if wallet_dir.starts_with(&network_dir) {
+            return Err(BackendError::Storage(
+                "wallet dir is inside network data dir; refusing to clear cache".to_string(),
+            ));
+        }
+
         if network_dir.exists() {
             std::fs::remove_dir_all(&network_dir).map_err(|e| {
                 BackendError::Storage(format!("failed to remove {}: {e}", network_dir.display()))
             })?;
         }
+
+        std::fs::create_dir_all(&network_dir).map_err(|e| {
+            BackendError::Storage(format!("failed to recreate {}: {e}", network_dir.display()))
+        })?;
 
         Ok(())
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -10,22 +10,16 @@ pub mod native;
 pub mod r#trait;
 pub mod types;
 
-/// Recursively compute the size of a directory, excluding a given path and its contents.
-fn dir_size_excluding(dir: &Path, exclude: Option<&Path>) -> u64 {
+/// Recursively compute the total size of a directory.
+fn dir_size(dir: &Path) -> u64 {
     let mut size = 0;
     let Ok(entries) = std::fs::read_dir(dir) else {
         return 0;
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        // Skip the exact excluded path and anything inside it
-        if let Some(exc) = exclude
-            && (path == exc || path.starts_with(exc))
-        {
-            continue;
-        }
         if path.is_dir() {
-            size += dir_size_excluding(&path, exclude);
+            size += dir_size(&path);
         } else {
             size += entry.metadata().map(|m| m.len()).unwrap_or(0);
         }
@@ -38,42 +32,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn dir_size_excluding_counts_files() {
+    fn dir_size_counts_files() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("a.dat"), vec![0u8; 100]).unwrap();
         std::fs::write(tmp.path().join("b.dat"), vec![0u8; 200]).unwrap();
-        assert_eq!(dir_size_excluding(tmp.path(), None), 300);
+        assert_eq!(dir_size(tmp.path()), 300);
     }
 
     #[test]
-    fn dir_size_excluding_skips_excluded_dir() {
+    fn dir_size_recurses_subdirectories() {
         let tmp = tempfile::tempdir().unwrap();
-        std::fs::create_dir(tmp.path().join("cache")).unwrap();
-        std::fs::write(tmp.path().join("cache/data.dat"), vec![0u8; 500]).unwrap();
-        std::fs::create_dir(tmp.path().join("wallets")).unwrap();
-        std::fs::write(tmp.path().join("wallets/wallet.mnemonic"), b"secret").unwrap();
-        let size = dir_size_excluding(tmp.path(), Some(tmp.path().join("wallets").as_path()));
-        assert_eq!(size, 500);
+        std::fs::create_dir(tmp.path().join("sub")).unwrap();
+        std::fs::write(tmp.path().join("sub/data.dat"), vec![0u8; 500]).unwrap();
+        std::fs::write(tmp.path().join("top.dat"), vec![0u8; 100]).unwrap();
+        assert_eq!(dir_size(tmp.path()), 600);
     }
 
     #[test]
-    fn dir_size_excluding_recurses_into_ancestors_of_excluded() {
+    fn dir_size_empty_dir() {
         let tmp = tempfile::tempdir().unwrap();
-        std::fs::create_dir(tmp.path().join("cache")).unwrap();
-        std::fs::write(tmp.path().join("cache/data.dat"), vec![0u8; 500]).unwrap();
-        let user_dir = tmp.path().join("user");
-        std::fs::create_dir(&user_dir).unwrap();
-        std::fs::write(user_dir.join("other.dat"), vec![0u8; 100]).unwrap();
-        std::fs::create_dir(user_dir.join("wallets")).unwrap();
-        std::fs::write(user_dir.join("wallets/wallet.mnemonic"), b"secret").unwrap();
-        // Excluding a nested path should still count sibling files in the ancestor
-        let size = dir_size_excluding(tmp.path(), Some(&tmp.path().join("user/wallets")));
-        assert_eq!(size, 600);
+        assert_eq!(dir_size(tmp.path()), 0);
     }
 
     #[test]
-    fn dir_size_excluding_empty_dir() {
-        let tmp = tempfile::tempdir().unwrap();
-        assert_eq!(dir_size_excluding(tmp.path(), None), 0);
+    fn dir_size_nonexistent_dir() {
+        assert_eq!(dir_size(Path::new("/nonexistent/path")), 0);
     }
 }

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -591,25 +591,9 @@ impl SpvBackend for NativeBackend {
             self.stop().await?;
         }
 
-        let network_dir = self.config.network_data_dir();
-        let wallet_dir = self.config.wallet_dir();
-        if wallet_dir.starts_with(&network_dir) {
-            return Err(BackendError::Storage(
-                "wallet dir is inside network data dir; refusing to clear cache".to_string(),
-            ));
-        }
-
-        if network_dir.exists() {
-            std::fs::remove_dir_all(&network_dir).map_err(|e| {
-                BackendError::Storage(format!("failed to remove {}: {e}", network_dir.display()))
-            })?;
-        }
-
-        std::fs::create_dir_all(&network_dir).map_err(|e| {
-            BackendError::Storage(format!("failed to recreate {}: {e}", network_dir.display()))
-        })?;
-
-        Ok(())
+        self.config
+            .clear_network_data_dir()
+            .map_err(|e| BackendError::Storage(e.to_string()))
     }
 
     fn subscribe_events(&self) -> EventReceiver {

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -145,7 +145,7 @@ impl SpvBackend for NativeBackend {
         }
 
         let mut client_config = ClientConfig::new(self.config.network)
-            .with_storage_path(self.config.data_dir.clone())
+            .with_storage_path(self.config.network_data_dir())
             .with_user_agent("dash-spv-ui");
 
         if self.config.network == Network::Regtest {
@@ -583,10 +583,7 @@ impl SpvBackend for NativeBackend {
     }
 
     fn cache_size(&self) -> BackendResult<u64> {
-        Ok(super::dir_size_excluding(
-            &self.config.data_dir,
-            Some(&self.config.wallet_dir()),
-        ))
+        Ok(super::dir_size(&self.config.network_data_dir()))
     }
 
     async fn clear_cache(&self) -> BackendResult<()> {
@@ -594,32 +591,11 @@ impl SpvBackend for NativeBackend {
             self.stop().await?;
         }
 
-        let data_dir = &self.config.data_dir;
-        let wallet_dir = self.config.wallet_dir();
-
-        let entries = std::fs::read_dir(data_dir)
-            .map_err(|e| BackendError::Storage(format!("failed to read data dir: {e}")))?;
-
-        for entry in entries.flatten() {
-            let path = entry.path();
-
-            // Skip if this path is or contains the wallet directory
-            if wallet_dir.starts_with(&path) || path.starts_with(&wallet_dir) {
-                continue;
-            }
-
-            // Skip config file
-            if path.file_name().is_some_and(|n| n == "config.toml") {
-                continue;
-            }
-
-            if path.is_dir() {
-                if let Err(e) = std::fs::remove_dir_all(&path) {
-                    tracing::warn!("Failed to remove cache dir {}: {e}", path.display());
-                }
-            } else if let Err(e) = std::fs::remove_file(&path) {
-                tracing::warn!("Failed to remove cache file {}: {e}", path.display());
-            }
+        let network_dir = self.config.network_data_dir();
+        if network_dir.exists() {
+            std::fs::remove_dir_all(&network_dir).map_err(|e| {
+                BackendError::Storage(format!("failed to remove {}: {e}", network_dir.display()))
+            })?;
         }
 
         Ok(())

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -592,11 +592,22 @@ impl SpvBackend for NativeBackend {
         }
 
         let network_dir = self.config.network_data_dir();
+        let wallet_dir = self.config.wallet_dir();
+        if wallet_dir.starts_with(&network_dir) {
+            return Err(BackendError::Storage(
+                "wallet dir is inside network data dir; refusing to clear cache".to_string(),
+            ));
+        }
+
         if network_dir.exists() {
             std::fs::remove_dir_all(&network_dir).map_err(|e| {
                 BackendError::Storage(format!("failed to remove {}: {e}", network_dir.display()))
             })?;
         }
+
+        std::fs::create_dir_all(&network_dir).map_err(|e| {
+            BackendError::Storage(format!("failed to recreate {}: {e}", network_dir.display()))
+        })?;
 
         Ok(())
     }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -630,6 +630,88 @@ mod tests {
     }
 
     #[test]
+    fn clear_network_data_dir_removes_and_recreates() {
+        let tmp = tempfile::tempdir().unwrap();
+        let network_dir = tmp.path().join("testnet");
+        fs::create_dir_all(&network_dir).unwrap();
+        fs::write(network_dir.join("some_file.dat"), b"data").unwrap();
+
+        let config = AppConfig {
+            data_dir: tmp.path().to_path_buf(),
+            network: Network::Testnet,
+            wallet_dir: Some(tmp.path().join("wallets")),
+            ..Default::default()
+        };
+
+        config.clear_network_data_dir().unwrap();
+
+        assert!(network_dir.exists(), "network dir should be recreated");
+        assert!(
+            !network_dir.join("some_file.dat").exists(),
+            "old contents should be removed"
+        );
+        assert!(
+            fs::read_dir(&network_dir).unwrap().next().is_none(),
+            "recreated dir should be empty"
+        );
+    }
+
+    #[test]
+    fn clear_network_data_dir_when_dir_does_not_exist() {
+        let tmp = tempfile::tempdir().unwrap();
+        let network_dir = tmp.path().join("testnet");
+        assert!(!network_dir.exists());
+
+        let config = AppConfig {
+            data_dir: tmp.path().to_path_buf(),
+            network: Network::Testnet,
+            wallet_dir: Some(tmp.path().join("wallets")),
+            ..Default::default()
+        };
+
+        config.clear_network_data_dir().unwrap();
+
+        assert!(network_dir.exists(), "network dir should be created");
+    }
+
+    #[test]
+    fn clear_network_data_dir_rejects_wallet_inside_network_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let network_dir = tmp.path().join("testnet");
+        fs::create_dir_all(&network_dir).unwrap();
+
+        let config = AppConfig {
+            data_dir: tmp.path().to_path_buf(),
+            network: Network::Testnet,
+            wallet_dir: Some(network_dir.join("wallets")),
+            ..Default::default()
+        };
+
+        let err = config.clear_network_data_dir().unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("wallet dir is inside network data dir"),
+            "expected wallet protection error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn clear_network_data_dir_allows_default_wallet_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Default wallet_dir is <data_dir>/wallets, which is a sibling of the
+        // network dir, not inside it.
+        let config = AppConfig {
+            data_dir: tmp.path().to_path_buf(),
+            network: Network::Testnet,
+            wallet_dir: None,
+            ..Default::default()
+        };
+
+        config.clear_network_data_dir().unwrap();
+        assert!(config.network_data_dir().exists());
+    }
+
+    #[test]
     fn invalid_mempool_strategy_is_rejected() {
         let toml_str = r#"
             network = "testnet"

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -143,9 +143,24 @@ impl AppConfig {
             .unwrap_or_else(|| self.data_dir.join("wallets"))
     }
 
-    /// Create all required directories (data, wallet, config).
+    /// Returns the network-specific data directory (e.g., `<data_dir>/testnet/`).
+    pub fn network_data_dir(&self) -> PathBuf {
+        self.data_dir.join(self.network_dir_name())
+    }
+
+    fn network_dir_name(&self) -> &str {
+        match self.network {
+            Network::Mainnet => "mainnet",
+            Network::Testnet => "testnet",
+            Network::Regtest => "regtest",
+            _ => "devnet",
+        }
+    }
+
+    /// Create all required directories (data, network-specific, wallet, config).
     pub fn ensure_dirs(&self) -> Result<(), ConfigError> {
         fs::create_dir_all(&self.data_dir).map_err(ConfigError::Io)?;
+        fs::create_dir_all(self.network_data_dir()).map_err(ConfigError::Io)?;
         fs::create_dir_all(self.wallet_dir()).map_err(ConfigError::Io)?;
         fs::create_dir_all(paths::config_dir()).map_err(ConfigError::Io)?;
         Ok(())
@@ -427,6 +442,34 @@ mod tests {
     }
 
     #[test]
+    fn network_data_dir_uses_network_name() {
+        let config = AppConfig {
+            data_dir: PathBuf::from("/data"),
+            network: Network::Testnet,
+            ..Default::default()
+        };
+        assert_eq!(config.network_data_dir(), PathBuf::from("/data/testnet"));
+
+        let config = AppConfig {
+            network: Network::Mainnet,
+            ..config
+        };
+        assert_eq!(config.network_data_dir(), PathBuf::from("/data/mainnet"));
+
+        let config = AppConfig {
+            network: Network::Regtest,
+            ..config
+        };
+        assert_eq!(config.network_data_dir(), PathBuf::from("/data/regtest"));
+
+        let config = AppConfig {
+            network: Network::Devnet,
+            ..config
+        };
+        assert_eq!(config.network_data_dir(), PathBuf::from("/data/devnet"));
+    }
+
+    #[test]
     fn ensure_dirs_creates_directories() {
         let tmp = std::env::temp_dir().join("dash-spv-ui-test-ensure-dirs");
         let _ = std::fs::remove_dir_all(&tmp);
@@ -439,6 +482,7 @@ mod tests {
         config.ensure_dirs().unwrap();
 
         assert!(config.data_dir.exists());
+        assert!(config.network_data_dir().exists());
         assert!(config.wallet_dir().exists());
 
         let _ = std::fs::remove_dir_all(&tmp);
@@ -457,6 +501,7 @@ mod tests {
         config.ensure_dirs().unwrap();
 
         assert!(config.data_dir.exists());
+        assert!(config.network_data_dir().exists());
         assert!(tmp.join("data").join("wallets").exists());
 
         let _ = std::fs::remove_dir_all(&tmp);

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -723,7 +723,10 @@ mod tests {
             fs::read_dir(&testnet_dir).unwrap().next().is_none(),
             "testnet dir should be empty"
         );
-        assert!(mainnet_dir.exists(), "sibling mainnet dir must not be removed");
+        assert!(
+            mainnet_dir.exists(),
+            "sibling mainnet dir must not be removed"
+        );
         assert!(
             mainnet_dir.join("blocks.dat").exists(),
             "sibling mainnet files must not be removed"

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -153,6 +153,7 @@ impl AppConfig {
             Network::Mainnet => "mainnet",
             Network::Testnet => "testnet",
             Network::Regtest => "regtest",
+            Network::Devnet => "devnet",
             _ => "devnet",
         }
     }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -696,6 +696,41 @@ mod tests {
     }
 
     #[test]
+    fn clear_network_data_dir_leaves_sibling_networks_untouched() {
+        let tmp = tempfile::tempdir().unwrap();
+        let testnet_dir = tmp.path().join("testnet");
+        let mainnet_dir = tmp.path().join("mainnet");
+        fs::create_dir_all(&testnet_dir).unwrap();
+        fs::create_dir_all(&mainnet_dir).unwrap();
+        fs::write(testnet_dir.join("blocks.dat"), b"testnet data").unwrap();
+        fs::write(mainnet_dir.join("blocks.dat"), b"mainnet data").unwrap();
+
+        let config = AppConfig {
+            data_dir: tmp.path().to_path_buf(),
+            network: Network::Testnet,
+            wallet_dir: Some(tmp.path().join("wallets")),
+            ..Default::default()
+        };
+
+        config.clear_network_data_dir().unwrap();
+
+        assert!(testnet_dir.exists(), "testnet dir should be recreated");
+        assert!(
+            !testnet_dir.join("blocks.dat").exists(),
+            "testnet contents should be cleared"
+        );
+        assert!(
+            fs::read_dir(&testnet_dir).unwrap().next().is_none(),
+            "testnet dir should be empty"
+        );
+        assert!(mainnet_dir.exists(), "sibling mainnet dir must not be removed");
+        assert!(
+            mainnet_dir.join("blocks.dat").exists(),
+            "sibling mainnet files must not be removed"
+        );
+    }
+
+    #[test]
     fn clear_network_data_dir_allows_default_wallet_dir() {
         let tmp = tempfile::tempdir().unwrap();
         // Default wallet_dir is <data_dir>/wallets, which is a sibling of the

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -158,6 +158,25 @@ impl AppConfig {
         }
     }
 
+    /// Remove and recreate the network-specific data directory.
+    ///
+    /// Returns an error if the wallet directory is inside the network data directory
+    /// to prevent accidental deletion of wallet data.
+    pub(crate) fn clear_network_data_dir(&self) -> Result<(), ConfigError> {
+        let network_dir = self.network_data_dir();
+        let wallet_dir = self.wallet_dir();
+        if wallet_dir.starts_with(&network_dir) {
+            return Err(ConfigError::Parse(
+                "wallet dir is inside network data dir; refusing to clear cache".to_string(),
+            ));
+        }
+        if network_dir.exists() {
+            fs::remove_dir_all(&network_dir).map_err(ConfigError::Io)?;
+        }
+        fs::create_dir_all(&network_dir).map_err(ConfigError::Io)?;
+        Ok(())
+    }
+
     /// Create all required directories (data, network-specific, wallet, config).
     pub fn ensure_dirs(&self) -> Result<(), ConfigError> {
         fs::create_dir_all(&self.data_dir).map_err(ConfigError::Io)?;


### PR DESCRIPTION
## Summary
- Add `AppConfig::network_data_dir()` returning `<data_dir>/<network>/` (e.g., `base/testnet/`)
- Both `NativeBackend` and `FfiBackend` pass the network-scoped path to `ClientConfig`/FFI
- `cache_size()` reflects current network only; `clear_cache()` deletes only the current network's subdirectory
- `ensure_dirs()` creates the network subdirectory on startup
- Wallet directory stays top-level at `<data_dir>/wallets/` (shared across networks)

Closes #113