### PR TITLE
refactor: add per-network config sections for peers and mempool strategy

### DIFF
--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -139,7 +139,7 @@ impl SpvBackend for FfiBackend {
         let app_network = self.config.network;
         let network = network_to_ffi(app_network);
         let data_dir = self.config.network_data_dir().display().to_string();
-        let peers = self.config.peers.clone();
+        let peers = self.config.peers().to_vec();
         let event_tx = self.event_tx.clone();
         let progress = self.progress.clone();
 

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -152,9 +152,9 @@ impl SpvBackend for NativeBackend {
             client_config = client_config.without_masternodes();
         }
 
-        if !self.config.peers.is_empty() {
+        if !self.config.peers().is_empty() {
             client_config.peers.clear();
-            for peer in &self.config.peers {
+            for peer in self.config.peers() {
                 if let Ok(addr) = peer.parse::<SocketAddr>() {
                     client_config.add_peer(addr);
                 }
@@ -162,7 +162,7 @@ impl SpvBackend for NativeBackend {
             client_config = client_config.with_restrict_to_configured_peers(true);
         }
 
-        let mempool_strategy = match self.config.mempool_strategy.as_str() {
+        let mempool_strategy = match self.config.mempool_strategy() {
             "fetch-all" => MempoolStrategy::FetchAll,
             _ => MempoolStrategy::BloomFilter,
         };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,4 @@
 mod paths;
 mod settings;
 
-pub use settings::AppConfig;
+pub use settings::{AppConfig, NetworkConfig};

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -8,11 +8,17 @@ use serde::{Deserialize, Serialize};
 
 use super::paths;
 
-/// Known network names used as TOML section keys.
-const NETWORK_KEYS: &[&str] = &["mainnet", "testnet", "devnet", "regtest"];
+/// Known network variants and their TOML section key names.
+/// Single source of truth for the network-to-key mapping.
+const NETWORK_ENTRIES: &[(Network, &str)] = &[
+    (Network::Mainnet, "mainnet"),
+    (Network::Testnet, "testnet"),
+    (Network::Devnet, "devnet"),
+    (Network::Regtest, "regtest"),
+];
 
 /// Per-network configuration for settings that vary by network.
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct NetworkConfig {
     /// Explicit peer addresses to connect to.
     /// When non-empty, the SPV client connects exclusively to these peers.
@@ -42,7 +48,7 @@ pub struct AppConfig {
     /// Backend selection (CLI-only, not persisted). "native" or "ffi".
     pub backend: String,
     /// Per-network configuration sections (e.g., `[testnet]`, `[mainnet]`).
-    pub networks: BTreeMap<String, NetworkConfig>,
+    pub(crate) networks: BTreeMap<String, NetworkConfig>,
 }
 
 /// Helper struct for serde that handles only the flat (non-network) fields.
@@ -70,6 +76,15 @@ fn default_window_height() -> u32 {
 
 fn default_mempool_strategy() -> String {
     "bloom-filter".to_string()
+}
+
+impl Default for NetworkConfig {
+    fn default() -> Self {
+        Self {
+            peers: Vec::new(),
+            mempool_strategy: default_mempool_strategy(),
+        }
+    }
 }
 
 impl Default for AppConfig {
@@ -127,7 +142,7 @@ impl<'de> Deserialize<'de> for AppConfig {
 
         // Extract network sections before deserializing the flat fields.
         let mut networks = BTreeMap::new();
-        for &key in NETWORK_KEYS {
+        for &(_, key) in NETWORK_ENTRIES {
             if let Some(val) = table.remove(key) {
                 let net_cfg: NetworkConfig = val.try_into().map_err(serde::de::Error::custom)?;
                 networks.insert(key.to_string(), net_cfg);
@@ -160,13 +175,12 @@ impl<'de> Deserialize<'de> for AppConfig {
 
 impl AppConfig {
     /// Returns the TOML section key for the given network.
-    fn network_key(network: Network) -> &'static str {
-        match network {
-            Network::Mainnet => "mainnet",
-            Network::Testnet => "testnet",
-            Network::Regtest => "regtest",
-            _ => "devnet",
-        }
+    pub(crate) fn network_key(network: Network) -> &'static str {
+        NETWORK_ENTRIES
+            .iter()
+            .find(|(n, _)| *n == network)
+            .map(|(_, key)| *key)
+            .unwrap_or("devnet")
     }
 
     /// Returns the active network's configuration.
@@ -276,7 +290,8 @@ impl AppConfig {
 
     /// Migrate old flat `peers` and `mempool_strategy` fields into the
     /// active network's section. Only applies when the raw TOML contains
-    /// these keys at the top level.
+    /// these keys at the top level and the active network does not already
+    /// have an explicit section in the file.
     fn migrate_legacy_fields(raw_toml: &str, config: &mut Self) {
         let table: toml::Table = match raw_toml.parse() {
             Ok(t) => t,
@@ -287,6 +302,13 @@ impl AppConfig {
         let has_legacy_strategy = table.get("mempool_strategy").is_some();
 
         if !has_legacy_peers && !has_legacy_strategy {
+            return;
+        }
+
+        // If the active network already has an explicit section in the raw
+        // TOML, don't overwrite it with legacy values.
+        let key = Self::network_key(config.network);
+        if table.get(key).is_some() {
             return;
         }
 
@@ -1049,6 +1071,41 @@ mod tests {
     }
 
     #[test]
+    fn network_config_mut_serializes_with_sensible_mempool_default() {
+        let mut config = AppConfig::default();
+        config.network_config_mut().peers = vec!["1.2.3.4:9999".to_string()];
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        assert!(
+            !toml_str.contains("mempool_strategy = \"\""),
+            "unexpected empty mempool_strategy in TOML: {toml_str}"
+        );
+        let restored: AppConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(restored.mempool_strategy(), "bloom-filter");
+    }
+
+    #[test]
+    fn legacy_migration_does_not_overwrite_per_network_values() {
+        let toml_str = r#"
+            network = "testnet"
+            data_dir = "/tmp"
+            dev_mode = false
+            log_level = "info"
+            peers = ["legacy-peer:19999"]
+            mempool_strategy = "fetch-all"
+
+            [testnet]
+            peers = ["explicit-peer:19999"]
+            mempool_strategy = "bloom-filter"
+        "#;
+
+        let mut config: AppConfig = toml::from_str(toml_str).unwrap();
+        AppConfig::migrate_legacy_fields(toml_str, &mut config);
+
+        assert_eq!(config.peers(), &["explicit-peer:19999"]);
+        assert_eq!(config.mempool_strategy(), "bloom-filter");
+    }
+
+    #[test]
     fn legacy_flat_config_migrates_to_per_network() {
         let toml_str = r#"
             network = "testnet"
@@ -1095,15 +1152,13 @@ mod tests {
             ..Default::default()
         };
         config.network_config_mut().mempool_strategy = "fetch-all".to_string();
-        config
-            .networks
-            .entry("testnet".to_string())
-            .or_default()
-            .mempool_strategy = "bloom-filter".to_string();
-
-        assert_eq!(config.mempool_strategy(), "fetch-all");
 
         config.network = Network::Testnet;
+        config.network_config_mut().mempool_strategy = "bloom-filter".to_string();
+
         assert_eq!(config.mempool_strategy(), "bloom-filter");
+
+        config.network = Network::Mainnet;
+        assert_eq!(config.mempool_strategy(), "fetch-all");
     }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 use std::{fmt, fs, io};
 
 use clap::Parser;
@@ -185,10 +186,7 @@ impl AppConfig {
 
     /// Returns the active network's configuration.
     pub fn network_config(&self) -> &NetworkConfig {
-        static DEFAULT: NetworkConfig = NetworkConfig {
-            peers: Vec::new(),
-            mempool_strategy: String::new(),
-        };
+        static DEFAULT: LazyLock<NetworkConfig> = LazyLock::new(NetworkConfig::default);
         self.networks
             .get(Self::network_key(self.network))
             .unwrap_or(&DEFAULT)

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -228,11 +228,16 @@ impl AppConfig {
     fn load_with_cli(cli: Cli, config_path: &std::path::Path) -> Result<Self, ConfigError> {
         let mut config = match fs::read_to_string(config_path) {
             Ok(contents) => {
-                let mut cfg = toml::from_str::<AppConfig>(&contents)
-                    .map_err(|e| ConfigError::Parse(e.to_string()))?;
+                let table: toml::Table = contents
+                    .parse()
+                    .map_err(|e: toml::de::Error| ConfigError::Parse(e.to_string()))?;
+
+                let mut cfg: AppConfig = toml::Value::Table(table.clone())
+                    .try_into()
+                    .map_err(|e: toml::de::Error| ConfigError::Parse(e.to_string()))?;
 
                 // Migrate legacy flat fields into the per-network section.
-                Self::migrate_legacy_fields(&contents, &mut cfg);
+                Self::migrate_legacy_fields(&table, &mut cfg);
 
                 cfg
             }
@@ -289,15 +294,10 @@ impl AppConfig {
     }
 
     /// Migrate old flat `peers` and `mempool_strategy` fields into the
-    /// active network's section. Only applies when the raw TOML contains
+    /// active network's section. Only applies when the parsed TOML contains
     /// these keys at the top level and the active network does not already
     /// have an explicit section in the file.
-    fn migrate_legacy_fields(raw_toml: &str, config: &mut Self) {
-        let table: toml::Table = match raw_toml.parse() {
-            Ok(t) => t,
-            Err(_) => return,
-        };
-
+    fn migrate_legacy_fields(table: &toml::Table, config: &mut Self) {
         let has_legacy_peers = table.get("peers").is_some();
         let has_legacy_strategy = table.get("mempool_strategy").is_some();
 
@@ -1098,8 +1098,9 @@ mod tests {
             mempool_strategy = "bloom-filter"
         "#;
 
+        let table: toml::Table = toml_str.parse().unwrap();
         let mut config: AppConfig = toml::from_str(toml_str).unwrap();
-        AppConfig::migrate_legacy_fields(toml_str, &mut config);
+        AppConfig::migrate_legacy_fields(&table, &mut config);
 
         assert_eq!(config.peers(), &["explicit-peer:19999"]);
         assert_eq!(config.mempool_strategy(), "bloom-filter");
@@ -1116,8 +1117,9 @@ mod tests {
             mempool_strategy = "fetch-all"
         "#;
 
+        let table: toml::Table = toml_str.parse().unwrap();
         let mut config: AppConfig = toml::from_str(toml_str).unwrap();
-        AppConfig::migrate_legacy_fields(toml_str, &mut config);
+        AppConfig::migrate_legacy_fields(&table, &mut config);
 
         assert_eq!(config.peers(), &["1.2.3.4:19999"]);
         assert_eq!(config.mempool_strategy(), "fetch-all");
@@ -1143,6 +1145,14 @@ mod tests {
         let config: AppConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.peers(), &["1.2.3.4:19999"]);
         assert_eq!(config.mempool_strategy(), "fetch-all");
+    }
+
+    #[test]
+    fn network_key_maps_all_variants() {
+        assert_eq!(AppConfig::network_key(Network::Mainnet), "mainnet");
+        assert_eq!(AppConfig::network_key(Network::Testnet), "testnet");
+        assert_eq!(AppConfig::network_key(Network::Devnet), "devnet");
+        assert_eq!(AppConfig::network_key(Network::Regtest), "regtest");
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::{fmt, fs, io};
 
@@ -7,25 +8,12 @@ use serde::{Deserialize, Serialize};
 
 use super::paths;
 
-/// Application configuration loaded from TOML file and CLI overrides.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AppConfig {
-    pub network: Network,
-    pub data_dir: PathBuf,
-    #[serde(default)]
-    pub wallet_dir: Option<PathBuf>,
-    pub dev_mode: bool,
-    pub log_level: String,
-    #[serde(default = "default_window_width")]
-    pub window_width: u32,
-    #[serde(default = "default_window_height")]
-    pub window_height: u32,
-    /// Use the in-memory mock backend (CLI-only, not persisted).
-    #[serde(skip)]
-    pub mock_mode: bool,
-    /// Backend selection (CLI-only, not persisted). "native" or "ffi".
-    #[serde(skip)]
-    pub backend: String,
+/// Known network names used as TOML section keys.
+const NETWORK_KEYS: &[&str] = &["mainnet", "testnet", "devnet", "regtest"];
+
+/// Per-network configuration for settings that vary by network.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct NetworkConfig {
     /// Explicit peer addresses to connect to.
     /// When non-empty, the SPV client connects exclusively to these peers.
     #[serde(default)]
@@ -33,6 +21,43 @@ pub struct AppConfig {
     /// Mempool strategy: "fetch-all" or "bloom-filter".
     #[serde(default = "default_mempool_strategy")]
     pub mempool_strategy: String,
+}
+
+/// Application configuration loaded from TOML file and CLI overrides.
+///
+/// Serialization and deserialization are handled manually so that
+/// per-network sections (e.g., `[testnet]`) appear as top-level TOML
+/// tables rather than nested under a `networks` key.
+#[derive(Debug, Clone)]
+pub struct AppConfig {
+    pub network: Network,
+    pub data_dir: PathBuf,
+    pub wallet_dir: Option<PathBuf>,
+    pub dev_mode: bool,
+    pub log_level: String,
+    pub window_width: u32,
+    pub window_height: u32,
+    /// Use the in-memory mock backend (CLI-only, not persisted).
+    pub mock_mode: bool,
+    /// Backend selection (CLI-only, not persisted). "native" or "ffi".
+    pub backend: String,
+    /// Per-network configuration sections (e.g., `[testnet]`, `[mainnet]`).
+    pub networks: BTreeMap<String, NetworkConfig>,
+}
+
+/// Helper struct for serde that handles only the flat (non-network) fields.
+#[derive(Serialize, Deserialize)]
+struct AppConfigFlat {
+    network: Network,
+    data_dir: PathBuf,
+    #[serde(default)]
+    wallet_dir: Option<PathBuf>,
+    dev_mode: bool,
+    log_level: String,
+    #[serde(default = "default_window_width")]
+    window_width: u32,
+    #[serde(default = "default_window_height")]
+    window_height: u32,
 }
 
 fn default_window_width() -> u32 {
@@ -59,13 +84,125 @@ impl Default for AppConfig {
             window_height: default_window_height(),
             mock_mode: false,
             backend: "native".to_string(),
-            peers: Vec::new(),
-            mempool_strategy: default_mempool_strategy(),
+            networks: BTreeMap::new(),
         }
     }
 }
 
+impl Serialize for AppConfig {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+
+        let flat = AppConfigFlat {
+            network: self.network,
+            data_dir: self.data_dir.clone(),
+            wallet_dir: self.wallet_dir.clone(),
+            dev_mode: self.dev_mode,
+            log_level: self.log_level.clone(),
+            window_width: self.window_width,
+            window_height: self.window_height,
+        };
+
+        let mut flat_value = toml::Value::try_from(&flat).map_err(serde::ser::Error::custom)?;
+        let table = flat_value
+            .as_table_mut()
+            .ok_or_else(|| serde::ser::Error::custom("expected table"))?;
+
+        for (key, net_cfg) in &self.networks {
+            let val = toml::Value::try_from(net_cfg).map_err(serde::ser::Error::custom)?;
+            table.insert(key.clone(), val);
+        }
+
+        let mut map = serializer.serialize_map(Some(table.len()))?;
+        for (k, v) in table {
+            map.serialize_entry(k, v)?;
+        }
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for AppConfig {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let mut table = toml::Table::deserialize(deserializer)?;
+
+        // Extract network sections before deserializing the flat fields.
+        let mut networks = BTreeMap::new();
+        for &key in NETWORK_KEYS {
+            if let Some(val) = table.remove(key) {
+                let net_cfg: NetworkConfig = val.try_into().map_err(serde::de::Error::custom)?;
+                networks.insert(key.to_string(), net_cfg);
+            }
+        }
+
+        // Remove legacy top-level fields that are no longer part of the flat struct.
+        // They will be migrated in `load()`.
+        table.remove("peers");
+        table.remove("mempool_strategy");
+
+        let flat: AppConfigFlat = toml::Value::Table(table)
+            .try_into()
+            .map_err(serde::de::Error::custom)?;
+
+        Ok(Self {
+            network: flat.network,
+            data_dir: flat.data_dir,
+            wallet_dir: flat.wallet_dir,
+            dev_mode: flat.dev_mode,
+            log_level: flat.log_level,
+            window_width: flat.window_width,
+            window_height: flat.window_height,
+            mock_mode: false,
+            backend: String::new(),
+            networks,
+        })
+    }
+}
+
 impl AppConfig {
+    /// Returns the TOML section key for the given network.
+    fn network_key(network: Network) -> &'static str {
+        match network {
+            Network::Mainnet => "mainnet",
+            Network::Testnet => "testnet",
+            Network::Regtest => "regtest",
+            _ => "devnet",
+        }
+    }
+
+    /// Returns the active network's configuration.
+    pub fn network_config(&self) -> &NetworkConfig {
+        static DEFAULT: NetworkConfig = NetworkConfig {
+            peers: Vec::new(),
+            mempool_strategy: String::new(),
+        };
+        self.networks
+            .get(Self::network_key(self.network))
+            .unwrap_or(&DEFAULT)
+    }
+
+    /// Returns a mutable reference to the active network's configuration,
+    /// creating a default entry if none exists.
+    pub fn network_config_mut(&mut self) -> &mut NetworkConfig {
+        let key = Self::network_key(self.network).to_string();
+        self.networks.entry(key).or_default()
+    }
+
+    /// Returns the peer list for the active network.
+    pub fn peers(&self) -> &[String] {
+        &self.network_config().peers
+    }
+
+    /// Returns the mempool strategy for the active network,
+    /// falling back to the default when the section is absent.
+    pub fn mempool_strategy(&self) -> &str {
+        let strategy = &self.network_config().mempool_strategy;
+        if strategy.is_empty() {
+            "bloom-filter"
+        } else {
+            strategy
+        }
+    }
+
     /// Load configuration by merging TOML file with CLI overrides.
     ///
     /// Priority: CLI args > TOML file > defaults.
@@ -76,8 +213,15 @@ impl AppConfig {
     /// Load configuration from `config_path`, applying CLI overrides from `cli`.
     fn load_with_cli(cli: Cli, config_path: &std::path::Path) -> Result<Self, ConfigError> {
         let mut config = match fs::read_to_string(config_path) {
-            Ok(contents) => toml::from_str::<AppConfig>(&contents)
-                .map_err(|e| ConfigError::Parse(e.to_string()))?,
+            Ok(contents) => {
+                let mut cfg = toml::from_str::<AppConfig>(&contents)
+                    .map_err(|e| ConfigError::Parse(e.to_string()))?;
+
+                // Migrate legacy flat fields into the per-network section.
+                Self::migrate_legacy_fields(&contents, &mut cfg);
+
+                cfg
+            }
             Err(e) if e.kind() == io::ErrorKind::NotFound => {
                 let default_config = Self::default();
                 let _ = default_config.save();
@@ -103,21 +247,21 @@ impl AppConfig {
             config.backend = backend;
         }
         if !cli.peer.is_empty() {
-            config.peers = cli.peer;
+            config.network_config_mut().peers = cli.peer;
         }
         if let Some(mempool_strategy) = cli.mempool_strategy {
-            config.mempool_strategy = mempool_strategy;
+            config.network_config_mut().mempool_strategy = mempool_strategy;
         }
         if let Some(data_dir) = cli.data_dir {
             config.data_dir = data_dir;
         }
 
-        // Validate mempool strategy.
+        // Validate mempool strategy for the active network.
         let valid_strategies = ["bloom-filter", "fetch-all"];
-        if !valid_strategies.contains(&config.mempool_strategy.as_str()) {
+        let strategy = config.mempool_strategy().to_string();
+        if !valid_strategies.contains(&strategy.as_str()) {
             return Err(ConfigError::Parse(format!(
-                "invalid mempool_strategy '{}': must be 'bloom-filter' or 'fetch-all'",
-                config.mempool_strategy
+                "invalid mempool_strategy '{strategy}': must be 'bloom-filter' or 'fetch-all'",
             )));
         }
 
@@ -128,6 +272,36 @@ impl AppConfig {
         }
 
         Ok(config)
+    }
+
+    /// Migrate old flat `peers` and `mempool_strategy` fields into the
+    /// active network's section. Only applies when the raw TOML contains
+    /// these keys at the top level.
+    fn migrate_legacy_fields(raw_toml: &str, config: &mut Self) {
+        let table: toml::Table = match raw_toml.parse() {
+            Ok(t) => t,
+            Err(_) => return,
+        };
+
+        let has_legacy_peers = table.get("peers").is_some();
+        let has_legacy_strategy = table.get("mempool_strategy").is_some();
+
+        if !has_legacy_peers && !has_legacy_strategy {
+            return;
+        }
+
+        let net_cfg = config.network_config_mut();
+
+        if let Some(toml::Value::Array(arr)) = table.get("peers") {
+            net_cfg.peers = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+        }
+
+        if let Some(toml::Value::String(s)) = table.get("mempool_strategy") {
+            net_cfg.mempool_strategy = s.clone();
+        }
     }
 
     /// Save the current configuration to the TOML file.
@@ -261,7 +435,7 @@ mod tests {
         assert_eq!(config.log_level, "info");
         assert!(config.wallet_dir.is_none());
         assert!(config.data_dir.components().count() > 0);
-        assert_eq!(config.mempool_strategy, "bloom-filter");
+        assert_eq!(config.mempool_strategy(), "bloom-filter");
     }
 
     #[test]
@@ -283,7 +457,7 @@ mod tests {
         assert_eq!(restored.wallet_dir, config.wallet_dir);
         assert_eq!(restored.dev_mode, config.dev_mode);
         assert_eq!(restored.log_level, config.log_level);
-        assert_eq!(restored.mempool_strategy, config.mempool_strategy);
+        assert_eq!(restored.mempool_strategy(), config.mempool_strategy());
     }
 
     #[test]
@@ -416,15 +590,14 @@ mod tests {
 
     #[test]
     fn peers_roundtrip_through_toml() {
-        let config = AppConfig {
-            peers: vec!["1.2.3.4:9999".to_string(), "5.6.7.8:19999".to_string()],
-            ..Default::default()
-        };
+        let mut config = AppConfig::default();
+        config.network_config_mut().peers =
+            vec!["1.2.3.4:9999".to_string(), "5.6.7.8:19999".to_string()];
 
         let toml_str = toml::to_string_pretty(&config).unwrap();
         let restored: AppConfig = toml::from_str(&toml_str).unwrap();
 
-        assert_eq!(restored.peers, config.peers);
+        assert_eq!(restored.peers(), config.peers());
     }
 
     #[test]
@@ -436,7 +609,7 @@ mod tests {
             log_level = "info"
         "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
-        assert!(config.peers.is_empty());
+        assert!(config.peers().is_empty());
     }
 
     #[test]
@@ -458,7 +631,7 @@ mod tests {
         assert_eq!(config.network, Network::Mainnet);
         assert!(config.wallet_dir.is_none());
         assert_eq!(config.window_width, 1024);
-        assert_eq!(config.mempool_strategy, "bloom-filter");
+        assert_eq!(config.mempool_strategy(), "bloom-filter");
     }
 
     #[test]
@@ -590,7 +763,7 @@ mod tests {
         let config = AppConfig::default();
         assert!(!config.mock_mode);
         assert_eq!(config.backend, "native");
-        assert!(config.peers.is_empty());
+        assert!(config.peers().is_empty());
     }
 
     #[test]
@@ -629,13 +802,12 @@ mod tests {
     #[test]
     fn mempool_strategy_roundtrip() {
         for strategy in ["bloom-filter", "fetch-all"] {
-            let config = AppConfig {
-                mempool_strategy: strategy.to_string(),
-                ..Default::default()
-            };
+            let mut config = AppConfig::default();
+            config.network_config_mut().mempool_strategy = strategy.to_string();
+
             let toml_str = toml::to_string_pretty(&config).unwrap();
             let restored: AppConfig = toml::from_str(&toml_str).unwrap();
-            assert_eq!(restored.mempool_strategy, strategy);
+            assert_eq!(restored.mempool_strategy(), strategy);
         }
     }
 
@@ -862,6 +1034,8 @@ mod tests {
                 data_dir = "/tmp"
                 dev_mode = false
                 log_level = "info"
+
+                [testnet]
                 mempool_strategy = "invalid-strategy"
             "#,
         );
@@ -872,5 +1046,64 @@ mod tests {
         assert!(err.contains("invalid mempool_strategy"));
 
         let _ = std::fs::remove_dir_all(config_path.parent().unwrap());
+    }
+
+    #[test]
+    fn legacy_flat_config_migrates_to_per_network() {
+        let toml_str = r#"
+            network = "testnet"
+            data_dir = "/tmp"
+            dev_mode = false
+            log_level = "info"
+            peers = ["1.2.3.4:19999"]
+            mempool_strategy = "fetch-all"
+        "#;
+
+        let mut config: AppConfig = toml::from_str(toml_str).unwrap();
+        AppConfig::migrate_legacy_fields(toml_str, &mut config);
+
+        assert_eq!(config.peers(), &["1.2.3.4:19999"]);
+        assert_eq!(config.mempool_strategy(), "fetch-all");
+    }
+
+    #[test]
+    fn per_network_config_from_toml() {
+        let toml_str = r#"
+            network = "testnet"
+            data_dir = "/tmp"
+            dev_mode = false
+            log_level = "info"
+
+            [testnet]
+            peers = ["1.2.3.4:19999"]
+            mempool_strategy = "fetch-all"
+
+            [mainnet]
+            peers = []
+            mempool_strategy = "bloom-filter"
+        "#;
+
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.peers(), &["1.2.3.4:19999"]);
+        assert_eq!(config.mempool_strategy(), "fetch-all");
+    }
+
+    #[test]
+    fn network_config_accessor_uses_active_network() {
+        let mut config = AppConfig {
+            network: Network::Mainnet,
+            ..Default::default()
+        };
+        config.network_config_mut().mempool_strategy = "fetch-all".to_string();
+        config
+            .networks
+            .entry("testnet".to_string())
+            .or_default()
+            .mempool_strategy = "bloom-filter".to_string();
+
+        assert_eq!(config.mempool_strategy(), "fetch-all");
+
+        config.network = Network::Testnet;
+        assert_eq!(config.mempool_strategy(), "bloom-filter");
     }
 }

--- a/src/screens/settings.rs
+++ b/src/screens/settings.rs
@@ -63,6 +63,25 @@ pub fn Settings() -> Element {
     let mut log_level = use_signal(|| config.log_level.clone());
     let mut mempool_strategy = use_signal(|| config.mempool_strategy().to_string());
 
+    // Reset mempool_strategy when the selected network changes so the UI
+    // reflects the correct per-network value.
+    use_effect(move || {
+        let selected = network();
+        let cfg = config_signal.read();
+        let strategy = cfg
+            .networks
+            .get(AppConfig::network_key(selected))
+            .map(|nc| {
+                if nc.mempool_strategy.is_empty() {
+                    "bloom-filter"
+                } else {
+                    nc.mempool_strategy.as_str()
+                }
+            })
+            .unwrap_or("bloom-filter");
+        mempool_strategy.set(strategy.to_string());
+    });
+
     let backends: &[&str] = if cfg!(feature = "ffi") {
         &["native", "ffi"]
     } else {
@@ -90,32 +109,21 @@ pub fn Settings() -> Element {
     };
 
     rsx! {
-        div {
-            class: "text-foreground p-6",
+        div { class: "text-foreground p-6",
 
-            h1 {
-                class: "text-2xl font-bold mb-6",
-                "Settings"
-            }
+            h1 { class: "text-2xl font-bold mb-6", "Settings" }
 
-            div {
-                class: "bg-card rounded-lg p-6 max-w-lg space-y-6",
+            div { class: "bg-card rounded-lg p-6 max-w-lg space-y-6",
 
                 // Network selector
                 div {
-                    label {
-                        class: "block text-muted text-sm uppercase tracking-wide mb-2",
+                    label { class: "block text-muted text-sm uppercase tracking-wide mb-2",
                         "Network"
                     }
-                    div {
-                        class: "flex gap-2",
-                        for &(name, net) in NETWORKS {
+                    div { class: "flex gap-2",
+                        for & (name , net) in NETWORKS {
                             button {
-                                class: if network() == net {
-                                    "px-4 py-2 rounded-lg bg-dash text-foreground font-medium"
-                                } else {
-                                    "px-4 py-2 rounded-lg bg-surface-alt text-muted hover:bg-hover transition-colors"
-                                },
+                                class: if network() == net { "px-4 py-2 rounded-lg bg-dash text-foreground font-medium" } else { "px-4 py-2 rounded-lg bg-surface-alt text-muted hover:bg-hover transition-colors" },
                                 onclick: move |_| network.set(net),
                                 "{name}"
                             }
@@ -125,8 +133,7 @@ pub fn Settings() -> Element {
 
                 // Data directory
                 div {
-                    label {
-                        class: "block text-muted text-sm uppercase tracking-wide mb-2",
+                    label { class: "block text-muted text-sm uppercase tracking-wide mb-2",
                         "Data Directory"
                     }
                     input {
@@ -139,8 +146,7 @@ pub fn Settings() -> Element {
 
                 // Wallet directory
                 div {
-                    label {
-                        class: "block text-muted text-sm uppercase tracking-wide mb-2",
+                    label { class: "block text-muted text-sm uppercase tracking-wide mb-2",
                         "Wallet Directory"
                     }
                     input {
@@ -153,44 +159,24 @@ pub fn Settings() -> Element {
                 }
 
                 // Dev mode toggle
-                div {
-                    class: "flex items-center justify-between",
-                    label {
-                        class: "text-muted text-sm uppercase tracking-wide",
-                        "Developer Mode"
-                    }
+                div { class: "flex items-center justify-between",
+                    label { class: "text-muted text-sm uppercase tracking-wide", "Developer Mode" }
                     button {
-                        class: if dev_mode() {
-                            "w-12 h-6 rounded-full bg-dash transition-colors relative"
-                        } else {
-                            "w-12 h-6 rounded-full bg-surface-alt transition-colors relative"
-                        },
+                        class: if dev_mode() { "w-12 h-6 rounded-full bg-dash transition-colors relative" } else { "w-12 h-6 rounded-full bg-surface-alt transition-colors relative" },
                         onclick: move |_| dev_mode.set(!dev_mode()),
-                        div {
-                            class: if dev_mode() {
-                                "w-5 h-5 rounded-full bg-foreground absolute top-0.5 right-0.5 transition-all"
-                            } else {
-                                "w-5 h-5 rounded-full bg-muted absolute top-0.5 left-0.5 transition-all"
-                            },
-                        }
+                        div { class: if dev_mode() { "w-5 h-5 rounded-full bg-foreground absolute top-0.5 right-0.5 transition-all" } else { "w-5 h-5 rounded-full bg-muted absolute top-0.5 left-0.5 transition-all" } }
                     }
                 }
 
                 // Log level selector
                 div {
-                    label {
-                        class: "block text-muted text-sm uppercase tracking-wide mb-2",
+                    label { class: "block text-muted text-sm uppercase tracking-wide mb-2",
                         "Log Level"
                     }
-                    div {
-                        class: "flex gap-2",
-                        for &level in LOG_LEVELS {
+                    div { class: "flex gap-2",
+                        for & level in LOG_LEVELS {
                             button {
-                                class: if log_level() == level {
-                                    "px-3 py-1 rounded-lg bg-dash text-foreground text-sm font-medium"
-                                } else {
-                                    "px-3 py-1 rounded-lg bg-surface-alt text-muted text-sm hover:bg-hover transition-colors"
-                                },
+                                class: if log_level() == level { "px-3 py-1 rounded-lg bg-dash text-foreground text-sm font-medium" } else { "px-3 py-1 rounded-lg bg-surface-alt text-muted text-sm hover:bg-hover transition-colors" },
                                 onclick: move |_| log_level.set(level.to_string()),
                                 "{level}"
                             }
@@ -200,53 +186,37 @@ pub fn Settings() -> Element {
 
                 // Mempool strategy selector
                 div {
-                    label {
-                        class: "block text-muted text-sm uppercase tracking-wide mb-2",
+                    label { class: "block text-muted text-sm uppercase tracking-wide mb-2",
                         "Mempool Strategy"
                     }
-                    div {
-                        class: "flex gap-2",
-                        for &(label, value) in MEMPOOL_STRATEGIES {
+                    div { class: "flex gap-2",
+                        for & (label , value) in MEMPOOL_STRATEGIES {
                             button {
-                                class: if mempool_strategy() == value {
-                                    "px-3 py-1 rounded-lg bg-dash text-foreground text-sm font-medium"
-                                } else {
-                                    "px-3 py-1 rounded-lg bg-surface-alt text-muted text-sm hover:bg-hover transition-colors"
-                                },
+                                class: if mempool_strategy() == value { "px-3 py-1 rounded-lg bg-dash text-foreground text-sm font-medium" } else { "px-3 py-1 rounded-lg bg-surface-alt text-muted text-sm hover:bg-hover transition-colors" },
                                 onclick: move |_| mempool_strategy.set(value.to_string()),
                                 "{label}"
                             }
                         }
                     }
-                    p {
-                        class: "text-muted text-xs mt-1",
-                        "Requires restart."
-                    }
+                    p { class: "text-muted text-xs mt-1", "Requires restart." }
                 }
 
                 // Backend selector (dev mode only)
                 if dev_mode() {
                     div {
-                        label {
-                            class: "block text-muted text-sm uppercase tracking-wide mb-2",
+                        label { class: "block text-muted text-sm uppercase tracking-wide mb-2",
                             "Backend"
                         }
-                        div {
-                            class: "flex gap-2",
-                            for &name in backends.iter() {
+                        div { class: "flex gap-2",
+                            for & name in backends.iter() {
                                 button {
-                                    class: if backend() == name {
-                                        "px-3 py-1 rounded-lg bg-dash text-foreground text-sm font-medium"
-                                    } else {
-                                        "px-3 py-1 rounded-lg bg-surface-alt text-muted text-sm hover:bg-hover transition-colors"
-                                    },
+                                    class: if backend() == name { "px-3 py-1 rounded-lg bg-dash text-foreground text-sm font-medium" } else { "px-3 py-1 rounded-lg bg-surface-alt text-muted text-sm hover:bg-hover transition-colors" },
                                     onclick: move |_| backend.set(name.to_string()),
                                     "{name}"
                                 }
                             }
                         }
-                        p {
-                            class: "text-muted text-xs mt-1",
+                        p { class: "text-muted text-xs mt-1",
                             "Requires restart. Use --backend flag at launch."
                         }
                     }
@@ -254,12 +224,10 @@ pub fn Settings() -> Element {
 
                 // Clear Cache
                 div {
-                    label {
-                        class: "block text-muted text-sm uppercase tracking-wide mb-2",
+                    label { class: "block text-muted text-sm uppercase tracking-wide mb-2",
                         "Cache"
                     }
-                    p {
-                        class: "text-foreground text-sm mb-2",
+                    p { class: "text-foreground text-sm mb-2",
                         "SPV data size: {format_bytes(cache_size())}"
                     }
                     match cache_state() {
@@ -271,12 +239,10 @@ pub fn Settings() -> Element {
                             }
                         },
                         ClearCacheState::Confirming => rsx! {
-                            p {
-                                class: "text-error text-sm mb-2",
+                            p { class: "text-error text-sm mb-2",
                                 "This will shut down the wallet and clear all sync data. The app will close and re-sync from scratch on next launch. Your wallet and settings will be preserved."
                             }
-                            div {
-                                class: "flex gap-2",
+                            div { class: "flex gap-2",
                                 button {
                                     class: "flex-1 bg-error hover:opacity-80 text-foreground font-medium py-2 px-4 rounded-lg transition-colors",
                                     onclick: move |_| async move {
@@ -302,17 +268,11 @@ pub fn Settings() -> Element {
                             }
                         },
                         ClearCacheState::Clearing => rsx! {
-                            p {
-                                class: "text-muted text-sm",
-                                "Clearing cache..."
-                            }
+                            p { class: "text-muted text-sm", "Clearing cache..." }
                         },
                     }
                     if let Some(err) = cache_error() {
-                        p {
-                            class: "text-error text-sm mt-1",
-                            "Failed to clear cache: {err}"
-                        }
+                        p { class: "text-error text-sm mt-1", "Failed to clear cache: {err}" }
                     }
                 }
 
@@ -326,16 +286,10 @@ pub fn Settings() -> Element {
                 // Status message
                 match save_status() {
                     Some(Ok(())) => rsx! {
-                        p {
-                            class: "text-success text-sm",
-                            "Saved. Restart to apply changes."
-                        }
+                        p { class: "text-success text-sm", "Saved. Restart to apply changes." }
                     },
                     Some(Err(e)) => rsx! {
-                        p {
-                            class: "text-error text-sm",
-                            "Failed to save: {e}"
-                        }
+                        p { class: "text-error text-sm", "Failed to save: {e}" }
                     },
                     None => rsx! {},
                 }

--- a/src/screens/settings.rs
+++ b/src/screens/settings.rs
@@ -67,19 +67,9 @@ pub fn Settings() -> Element {
     // reflects the correct per-network value.
     use_effect(move || {
         let selected = network();
-        let cfg = config_signal.read();
-        let strategy = cfg
-            .networks
-            .get(AppConfig::network_key(selected))
-            .map(|nc| {
-                if nc.mempool_strategy.is_empty() {
-                    "bloom-filter"
-                } else {
-                    nc.mempool_strategy.as_str()
-                }
-            })
-            .unwrap_or("bloom-filter");
-        mempool_strategy.set(strategy.to_string());
+        let mut cfg = config_signal.read().clone();
+        cfg.network = selected;
+        mempool_strategy.set(cfg.mempool_strategy().to_string());
     });
 
     let backends: &[&str] = if cfg!(feature = "ffi") {

--- a/src/screens/settings.rs
+++ b/src/screens/settings.rs
@@ -61,7 +61,7 @@ pub fn Settings() -> Element {
     let mut network = use_signal(|| config.network);
     let mut dev_mode = use_signal(|| config.dev_mode);
     let mut log_level = use_signal(|| config.log_level.clone());
-    let mut mempool_strategy = use_signal(|| config.mempool_strategy.clone());
+    let mut mempool_strategy = use_signal(|| config.mempool_strategy().to_string());
 
     let backends: &[&str] = if cfg!(feature = "ffi") {
         &["native", "ffi"]
@@ -81,7 +81,7 @@ pub fn Settings() -> Element {
         };
         cfg.dev_mode = dev_mode();
         cfg.log_level = log_level();
-        cfg.mempool_strategy = mempool_strategy();
+        cfg.network_config_mut().mempool_strategy = mempool_strategy();
 
         match cfg.save() {
             Ok(()) => save_status.set(Some(Ok(()))),

--- a/tests/dashd_sync/setup.rs
+++ b/tests/dashd_sync/setup.rs
@@ -56,15 +56,16 @@ impl BackendTestContext {
         std::fs::create_dir_all(&data_dir).expect("failed to create data dir");
         std::fs::create_dir_all(&wallet_dir).expect("failed to create wallet dir");
 
-        AppConfig {
+        let mut config = AppConfig {
             network: Network::Regtest,
             data_dir,
             wallet_dir: Some(wallet_dir),
             dev_mode: true,
             log_level: "debug".to_string(),
-            peers: vec![self.dashd.addr.to_string()],
             ..Default::default()
-        }
+        };
+        config.network_config_mut().peers = vec![self.dashd.addr.to_string()];
+        config
     }
 }
 

--- a/tests/dashd_sync/setup.rs
+++ b/tests/dashd_sync/setup.rs
@@ -56,14 +56,12 @@ impl BackendTestContext {
         std::fs::create_dir_all(&data_dir).expect("failed to create data dir");
         std::fs::create_dir_all(&wallet_dir).expect("failed to create wallet dir");
 
-        let mut config = AppConfig {
-            network: Network::Regtest,
-            data_dir,
-            wallet_dir: Some(wallet_dir),
-            dev_mode: true,
-            log_level: "debug".to_string(),
-            ..Default::default()
-        };
+        let mut config = AppConfig::default();
+        config.network = Network::Regtest;
+        config.data_dir = data_dir;
+        config.wallet_dir = Some(wallet_dir);
+        config.dev_mode = true;
+        config.log_level = "debug".to_string();
         config.network_config_mut().peers = vec![self.dashd.addr.to_string()];
         config
     }


### PR DESCRIPTION
## Summary
- Restructure `config.toml` to use per-network TOML sections (`[testnet]`, `[mainnet]`, etc.) for `peers` and `mempool_strategy`
- Add `NetworkConfig` struct and `AppConfig::network_config()` / `network_config_mut()` accessors
- Custom serde implementation for `AppConfig` to serialize network sections as top-level TOML tables
- Legacy flat configs with top-level `peers`/`mempool_strategy` are automatically migrated to the active network's section
- Backends and settings screen updated to use the new per-network accessors

Closes #114