### PR TITLE
ci: add bundle config to Dioxus.toml

### DIFF
--- a/Dioxus.toml
+++ b/Dioxus.toml
@@ -3,3 +3,16 @@ name = "Dash SPV Wallet"
 default_platform = "desktop"
 out_dir = "dist"
 asset_dir = "assets"
+
+[bundle]
+identifier = "org.dash.spv-wallet"
+publisher = "Dash Core Group"
+icon = ["assets/icons/AppIcon.icns", "assets/icons/AppIcon.ico", "assets/icons/icon_256x256.png"]
+short_description = "Cross-platform Dash SPV wallet"
+copyright = "Dash Core Group"
+
+[bundle.macos]
+minimum_system_version = "11.0"
+
+[bundle.deb]
+depends = ["libwebkit2gtk-4.1-0", "libgtk-3-0"]


### PR DESCRIPTION
## Summary
- Add `[bundle]` section with identifier (`org.dash.spv-wallet`), publisher, icon paths, description
- Add `[bundle.macos]` with `minimum_system_version = "11.0"`
- Add `[bundle.deb]` with runtime dependencies (`libwebkit2gtk-4.1-0`, `libgtk-3-0`)

Closes #129