### PR TITLE
ci: add release and nightly build workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,174 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  schedule:
+    - cron: '17 4 * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-nightly:
+    name: Check for new commits
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.check.outputs.should_build }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for recent commits
+        id: check
+        run: |
+          if git log --since="25 hours ago" --oneline | head -1 | grep -q .; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build (${{ matrix.target }})
+    needs: check-nightly
+    if: |
+      always() &&
+      (needs.check-nightly.result == 'skipped' || needs.check-nightly.outputs.should_build == 'true')
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            package_types: dmg
+            artifact_name: dash-spv-wallet-macos-x86_64
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            package_types: dmg
+            artifact_name: dash-spv-wallet-macos-arm64
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-24.04
+            package_types: deb
+            artifact_name: dash-spv-wallet-linux-x86_64
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            package_types: msi
+            artifact_name: dash-spv-wallet-windows-x86_64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev libxdo-dev libglib2.0-dev
+
+      - name: Install Dioxus CLI
+        shell: bash
+        run: |
+          DX_VERSION="0.7.3"
+          mkdir -p "$HOME/.cargo/bin"
+          case "${{ matrix.target }}" in
+            x86_64-unknown-linux-gnu)
+              DX_ARCHIVE="dx-x86_64-unknown-linux-gnu.tar.gz"
+              curl -fsSL "https://github.com/DioxusLabs/dioxus/releases/download/v${DX_VERSION}/${DX_ARCHIVE}" \
+                | tar -xz -C "$HOME/.cargo/bin"
+              chmod +x "$HOME/.cargo/bin/dx"
+              ;;
+            x86_64-apple-darwin)
+              DX_ARCHIVE="dx-x86_64-apple-darwin.tar.gz"
+              curl -fsSL "https://github.com/DioxusLabs/dioxus/releases/download/v${DX_VERSION}/${DX_ARCHIVE}" \
+                | tar -xz -C "$HOME/.cargo/bin"
+              chmod +x "$HOME/.cargo/bin/dx"
+              ;;
+            aarch64-apple-darwin)
+              DX_ARCHIVE="dx-aarch64-apple-darwin.tar.gz"
+              curl -fsSL "https://github.com/DioxusLabs/dioxus/releases/download/v${DX_VERSION}/${DX_ARCHIVE}" \
+                | tar -xz -C "$HOME/.cargo/bin"
+              chmod +x "$HOME/.cargo/bin/dx"
+              ;;
+            x86_64-pc-windows-msvc)
+              DX_ARCHIVE="dx-x86_64-pc-windows-msvc.zip"
+              curl -fsSL -o "$RUNNER_TEMP/dx.zip" "https://github.com/DioxusLabs/dioxus/releases/download/v${DX_VERSION}/${DX_ARCHIVE}"
+              unzip -o "$RUNNER_TEMP/dx.zip" -d "$HOME/.cargo/bin"
+              ;;
+          esac
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - run: npm install
+
+      - name: Bundle application
+        shell: bash
+        run: dx bundle --platform desktop --release --package-types "${{ matrix.package_types }}"
+
+      - name: Create Linux tarball
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          BINARY=$(find dist/bundle -type f -executable -name "dash-spv-wallet" 2>/dev/null || find target/release -maxdepth 1 -type f -executable -name "dash-spv-wallet" 2>/dev/null)
+          if [ -n "$BINARY" ]; then
+            tar -czf dist/bundle/dash-spv-wallet-linux-x86_64.tar.gz -C "$(dirname "$BINARY")" "$(basename "$BINARY")"
+          fi
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: dist/bundle/
+          retention-days: 7
+
+  release:
+    name: Create Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            artifacts/**/*
+
+  nightly-release:
+    name: Nightly Release
+    if: github.event_name == 'schedule'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create/update nightly release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: nightly
+          name: Nightly Build
+          prerelease: true
+          files: |
+            artifacts/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
   check-nightly:
@@ -106,10 +106,14 @@ jobs:
               curl -fsSL -o "$RUNNER_TEMP/dx.zip" "https://github.com/DioxusLabs/dioxus/releases/download/v${DX_VERSION}/${DX_ARCHIVE}"
               unzip -o "$RUNNER_TEMP/dx.zip" -d "$HOME/.cargo/bin"
               ;;
+            *)
+              echo "Unsupported target: ${{ matrix.target }}" >&2
+              exit 1
+              ;;
           esac
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
-      - run: npm install
+      - run: npm ci
 
       - name: Bundle application
         shell: bash
@@ -120,9 +124,11 @@ jobs:
         shell: bash
         run: |
           BINARY=$(find dist/bundle -type f -executable -name "dash-spv-wallet" 2>/dev/null || find target/release -maxdepth 1 -type f -executable -name "dash-spv-wallet" 2>/dev/null)
-          if [ -n "$BINARY" ]; then
-            tar -czf dist/bundle/dash-spv-wallet-linux-x86_64.tar.gz -C "$(dirname "$BINARY")" "$(basename "$BINARY")"
+          if [ -z "$BINARY" ]; then
+            echo "Error: could not locate dash-spv-wallet binary" >&2
+            exit 1
           fi
+          tar -czf dist/bundle/dash-spv-wallet-linux-x86_64.tar.gz -C "$(dirname "$BINARY")" "$(basename "$BINARY")"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -159,6 +165,13 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Update nightly tag
+        run: |
+          git tag -f nightly
+          git push origin nightly --force
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` with three triggers: tag push (`v*`), nightly schedule (4:17 AM UTC), and `workflow_dispatch` for testing
- Build matrix: macOS arm64/x86_64 (`.dmg`), Linux x86_64 (`.deb` + `.tar.gz`), Windows x86_64 (`.msi`)
- Tag pushes create a GitHub Release with auto-generated release notes
- Nightly builds create/update a rolling `nightly` pre-release (only if commits exist)
- `workflow_dispatch` builds artifacts without creating a release (for testing)

Closes #130