### PR TITLE
fix: use available macOS runner for x86_64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-latest
             package_types: dmg
             artifact_name: dash-spv-wallet-macos-x86_64
           - target: aarch64-apple-darwin


### PR DESCRIPTION
## Summary
- Change `macos-13` to `macos-latest` for x86_64 macOS builds — `macos-13` runners are no longer available
- Cross-compilation to x86_64 handled by the Rust target (`x86_64-apple-darwin`)