### PR TITLE
fix: correct release workflow artifact paths, dx version, and icon config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install Dioxus CLI
         shell: bash
         run: |
-          DX_VERSION="0.7.3"
+          DX_VERSION="0.7.4"
           mkdir -p "$HOME/.cargo/bin"
           case "${{ matrix.target }}" in
             x86_64-unknown-linux-gnu)
@@ -123,18 +123,20 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          BINARY=$(find dist/bundle -type f -executable -name "dash-spv-wallet" 2>/dev/null || find target/release -maxdepth 1 -type f -executable -name "dash-spv-wallet" 2>/dev/null)
+          BINARY=$(find target/dx -type f -executable -name "dash-spv-wallet" 2>/dev/null \
+                   || find target/release -maxdepth 1 -type f -executable -name "dash-spv-wallet" 2>/dev/null)
           if [ -z "$BINARY" ]; then
             echo "Error: could not locate dash-spv-wallet binary" >&2
+            find target/dx -type f -executable 2>/dev/null || true
             exit 1
           fi
-          tar -czf dist/bundle/dash-spv-wallet-linux-x86_64.tar.gz -C "$(dirname "$BINARY")" "$(basename "$BINARY")"
+          tar -czf dist/dash-spv-wallet-linux-x86_64.tar.gz -C "$(dirname "$BINARY")" "$(basename "$BINARY")"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
-          path: dist/bundle/
+          path: dist/
           retention-days: 7
 
   release:


### PR DESCRIPTION
## Summary
- Fix artifact upload path: `dist/` not `dist/bundle/` (dx bundle outputs to `dist/`)
- Update dx CLI from 0.7.3 to 0.7.4 to match dioxus dependency (fixes version mismatch error and Windows icon path issue)
- Fix Linux tarball step: search `target/dx/` for the binary instead of `dist/bundle/`
- Use `macos-latest` for x86_64 macOS (cherry-picked from #135, `macos-13` no longer available)

Supersedes #135