### PR TITLE
chore: update to latest upstream `feat/dash-spv-wallet` branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
 dependencies = [
  "clap",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "proc-macro2",
  "quote",
@@ -984,7 +984,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#09228787e72220dc6c17c7a1eecbd4d2bcba7707"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -998,7 +998,7 @@ dependencies = [
  "futures",
  "hex",
  "hickory-resolver",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "key-wallet",
  "key-wallet-manager",
  "log",
@@ -1019,7 +1019,7 @@ dependencies = [
 [[package]]
 name = "dash-spv-ffi"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#09228787e72220dc6c17c7a1eecbd4d2bcba7707"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
 dependencies = [
  "cbindgen",
  "clap",
@@ -1068,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#09228787e72220dc6c17c7a1eecbd4d2bcba7707"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1093,12 +1093,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#09228787e72220dc6c17c7a1eecbd4d2bcba7707"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#09228787e72220dc6c17c7a1eecbd4d2bcba7707"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1111,7 +1111,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#09228787e72220dc6c17c7a1eecbd4d2bcba7707"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1126,7 +1126,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#09228787e72220dc6c17c7a1eecbd4d2bcba7707"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2675,12 +2675,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2688,9 +2689,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2701,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2715,15 +2716,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2735,15 +2736,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2800,9 +2801,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -3002,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#09228787e72220dc6c17c7a1eecbd4d2bcba7707"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
 dependencies = [
  "aes",
  "async-trait",
@@ -3030,7 +3031,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#09228787e72220dc6c17c7a1eecbd4d2bcba7707"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
 dependencies = [
  "cbindgen",
  "dashcore",
@@ -3045,7 +3046,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#09228787e72220dc6c17c7a1eecbd4d2bcba7707"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3075,7 +3076,7 @@ checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
  "cssparser",
  "html5ever",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "selectors",
 ]
 
@@ -3123,9 +3124,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -3183,9 +3184,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -3403,9 +3404,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a"
+checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -4063,9 +4064,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -4127,7 +4128,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.9+spec-1.1.0",
+ "toml_edit 0.25.10+spec-1.1.0",
 ]
 
 [[package]]
@@ -4724,7 +4725,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "itoa",
  "memchr",
  "serde",
@@ -5342,9 +5343,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5437,7 +5438,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -5479,7 +5480,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -5490,7 +5491,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
@@ -5499,11 +5500,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.9+spec-1.1.0"
+version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da053d28fe57e2c9d21b48261e14e7b4c8b670b54d2c684847b91feaf4c7dac5"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.1",
@@ -5511,9 +5512,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.1",
 ]
@@ -5925,7 +5926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -5951,7 +5952,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "semver",
 ]
 
@@ -6552,7 +6553,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -6583,7 +6584,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -6602,7 +6603,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "semver",
  "serde",
@@ -6614,9 +6615,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
@@ -6716,9 +6717,9 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6727,9 +6728,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6759,18 +6760,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6800,9 +6801,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6811,9 +6812,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6822,9 +6823,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1585,6 +1585,7 @@ fn extract_ffi_input_addresses(record: &FFITransactionRecord) -> Vec<String> {
             }
         })
         .collect();
+    addrs.sort();
     addrs.dedup();
     addrs
 }

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -598,7 +598,7 @@ impl SpvBackend for FfiBackend {
                     };
 
                     let block_info = &record.context.block_info;
-                    let has_block = block_info.block_hash != [0u8; 32] || block_info.timestamp != 0;
+                    let has_block = block_info.block_hash != [0u8; 32] && block_info.timestamp != 0;
                     let is_instant_send = matches!(
                         record.context.context_type,
                         FFITransactionContextType::InstantSend
@@ -1471,7 +1471,7 @@ extern "C" fn on_transaction_received(
     let (is_instant_send, is_chain_locked) = ffi_transaction_context_flags(r.context.context_type);
 
     let block_info = &r.context.block_info;
-    let has_block = block_info.block_hash != [0u8; 32] || block_info.timestamp != 0;
+    let has_block = block_info.block_hash != [0u8; 32] && block_info.timestamp != 0;
 
     let addresses = extract_ffi_input_addresses(r);
 

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -50,7 +50,7 @@ use key_wallet_ffi::managed_wallet::{
 };
 use key_wallet_ffi::mnemonic::{mnemonic_free, mnemonic_generate};
 use key_wallet_ffi::types::FFIAccountType;
-use key_wallet_ffi::types::{FFINetwork, FFITransactionContext};
+use key_wallet_ffi::types::{FFINetwork, FFITransactionContextType};
 use key_wallet_ffi::utxo::{managed_wallet_get_utxos, utxo_array_free};
 use key_wallet_ffi::wallet::wallet_free_const;
 use key_wallet_ffi::wallet_manager::{
@@ -601,11 +601,11 @@ impl SpvBackend for FfiBackend {
                     let has_block = block_info.block_hash != [0u8; 32] || block_info.timestamp != 0;
                     let is_instant_send = matches!(
                         record.context.context_type,
-                        FFITransactionContext::InstantSend
+                        FFITransactionContextType::InstantSend
                     );
                     let is_chain_locked = matches!(
                         record.context.context_type,
-                        FFITransactionContext::InChainLockedBlock
+                        FFITransactionContextType::InChainLockedBlock
                     );
 
                     transactions.push(TransactionInfo {
@@ -1454,46 +1454,46 @@ extern "C" fn on_peers_updated(connected_count: u32, best_height: u32, user_data
 
 extern "C" fn on_transaction_received(
     _wallet_id: *const c_char,
-    status: FFITransactionContext,
     _account_index: u32,
-    txid: *const [u8; 32],
-    amount: i64,
-    addresses: *const c_char,
+    record: *const FFITransactionRecord,
     user_data: *mut c_void,
 ) {
     // Safety: user_data is a valid CallbackContext pointer (borrowed, not owned).
     let ctx = unsafe { &*(user_data as *const CallbackContext) };
 
-    let txid_bytes = if txid.is_null() {
-        [0u8; 32]
-    } else {
-        // Safety: txid is a valid pointer to a 32-byte array (callback contract).
-        unsafe { *txid }
-    };
+    if record.is_null() {
+        return;
+    }
 
-    let addr_list = if addresses.is_null() {
-        Vec::new()
-    } else {
-        // Safety: addresses is a borrowed C string valid for the duration of the callback.
-        let addr_str = unsafe { CStr::from_ptr(addresses) }
-            .to_string_lossy()
-            .into_owned();
-        addr_str
-            .split(',')
-            .filter(|s| !s.is_empty())
-            .map(String::from)
-            .collect()
-    };
+    // Safety: record is a valid pointer to an FFITransactionRecord (callback contract).
+    let r = unsafe { &*record };
 
-    let (is_instant_send, is_chain_locked) = ffi_transaction_context_flags(status);
+    let (is_instant_send, is_chain_locked) = ffi_transaction_context_flags(r.context.context_type);
+
+    let block_info = &r.context.block_info;
+    let has_block = block_info.block_hash != [0u8; 32] || block_info.timestamp != 0;
+
+    let addresses = extract_ffi_input_addresses(r);
 
     let _ = ctx.event_tx.send(SpvEvent::TransactionReceived {
-        txid: txid_bytes,
-        amount,
-        addresses: addr_list,
-        height: None,
-        timestamp: None,
-        block_hash: None,
+        txid: r.txid,
+        amount: r.net_amount,
+        addresses,
+        height: if has_block {
+            Some(block_info.height)
+        } else {
+            None
+        },
+        timestamp: if has_block {
+            Some(block_info.timestamp as u64)
+        } else {
+            None
+        },
+        block_hash: if has_block {
+            Some(block_info.block_hash)
+        } else {
+            None
+        },
         is_instant_send,
         is_chain_locked,
     });
@@ -1552,11 +1552,39 @@ extern "C" fn on_client_error(error: *const c_char, user_data: *mut c_void) {
     let _ = ctx.event_tx.send(SpvEvent::Error(msg));
 }
 
-/// Extract `(is_instant_send, is_chain_locked)` from an `FFITransactionContext`.
-fn ffi_transaction_context_flags(status: FFITransactionContext) -> (bool, bool) {
-    match status {
-        FFITransactionContext::InstantSend => (true, false),
-        FFITransactionContext::InChainLockedBlock => (false, true),
-        FFITransactionContext::Mempool | FFITransactionContext::InBlock => (false, false),
+/// Extract `(is_instant_send, is_chain_locked)` from an `FFITransactionContextType`.
+fn ffi_transaction_context_flags(ctx_type: FFITransactionContextType) -> (bool, bool) {
+    match ctx_type {
+        FFITransactionContextType::InstantSend => (true, false),
+        FFITransactionContextType::InChainLockedBlock => (false, true),
+        FFITransactionContextType::Mempool | FFITransactionContextType::InBlock => (false, false),
     }
+}
+
+/// Extract addresses from an `FFITransactionRecord`'s input details.
+fn extract_ffi_input_addresses(record: &FFITransactionRecord) -> Vec<String> {
+    if record.input_details.is_null() || record.input_details_count == 0 {
+        return Vec::new();
+    }
+    // Safety: input_details is a valid pointer to an array of input_details_count elements
+    // (guaranteed by the FFI contract for the lifetime of the callback).
+    let details =
+        unsafe { std::slice::from_raw_parts(record.input_details, record.input_details_count) };
+    let mut addrs: Vec<String> = details
+        .iter()
+        .filter_map(|d| {
+            if d.address.is_null() {
+                None
+            } else {
+                // Safety: address is a valid C string for the duration of the callback.
+                Some(
+                    unsafe { CStr::from_ptr(d.address) }
+                        .to_string_lossy()
+                        .into_owned(),
+                )
+            }
+        })
+        .collect();
+    addrs.dedup();
+    addrs
 }

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -773,7 +773,7 @@ mod tests {
     use dashcore::hashes::Hash;
     use dashcore::{Address, BlockHash, PublicKey, Txid};
     use key_wallet::managed_account::transaction_record::{
-        TransactionDirection as RecordDirection, TransactionRecord,
+        InputDetail, TransactionDirection as RecordDirection, TransactionRecord,
     };
     use key_wallet::transaction_checking::TransactionContext;
     use key_wallet::transaction_checking::transaction_context::BlockInfo;
@@ -1135,5 +1135,41 @@ mod tests {
             mapped,
             SpvEvent::BalanceUpdated(WalletCoreBalance::new(100_000, 50_000, 25_000, 10_000))
         );
+    }
+
+    #[test]
+    fn extract_record_addresses_deduplicates() {
+        let addr_a = test_address();
+        // Create a distinct address using a different public key
+        let pk_b = PublicKey::from_slice(&[
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x02,
+        ])
+        .unwrap();
+        let addr_b = Address::p2pkh(&pk_b, Network::Testnet);
+
+        let input_details = vec![
+            InputDetail { index: 0, value: 1000, address: addr_a.clone() },
+            InputDetail { index: 1, value: 2000, address: addr_a.clone() },
+            InputDetail { index: 2, value: 3000, address: addr_b.clone() },
+            InputDetail { index: 3, value: 4000, address: addr_b.clone() },
+        ];
+
+        let tx = Transaction::dummy_empty();
+        let record = TransactionRecord::new(
+            tx,
+            TransactionContext::Mempool,
+            TransactionType::Standard,
+            RecordDirection::Incoming,
+            input_details,
+            Vec::new(),
+            10000,
+        );
+
+        let addresses = extract_record_addresses(&record);
+        assert_eq!(addresses.len(), 2);
+        assert!(addresses.contains(&addr_a.to_string()));
+        assert!(addresses.contains(&addr_b.to_string()));
     }
 }

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -375,7 +375,7 @@ impl SpvBackend for NativeBackend {
                     TransactionDirection::Sent
                 };
                 let block_info = r.context.block_info();
-                let is_instant_send = r.context == TransactionContext::InstantSend;
+                let is_instant_send = matches!(r.context, TransactionContext::InstantSend(_));
                 let is_chain_locked =
                     matches!(r.context, TransactionContext::InChainLockedBlock(_));
                 TransactionInfo {
@@ -643,13 +643,10 @@ fn map_sync_event(event: SyncEvent) -> Option<SpvEvent> {
         SyncEvent::InstantLockReceived {
             instant_lock,
             validated,
-        } => {
-            use dashcore::hashes::Hash;
-            Some(SpvEvent::InstantLockReceived {
-                txid: instant_lock.txid.to_byte_array(),
-                validated,
-            })
-        }
+        } => Some(SpvEvent::InstantLockReceived {
+            txid: instant_lock.txid.to_byte_array(),
+            validated,
+        }),
         SyncEvent::ManagerError { manager, error } => {
             Some(SpvEvent::Error(format!("{manager}: {error}")))
         }
@@ -677,19 +674,16 @@ fn map_network_event(event: NetworkEvent) -> SpvEvent {
 fn map_wallet_event(event: WalletEvent) -> SpvEvent {
     match event {
         WalletEvent::TransactionReceived {
-            txid,
-            amount,
-            addresses,
-            status,
-            ..
+            wallet_id: _,
+            account_index: _,
+            record,
         } => {
-            use dashcore::hashes::Hash;
             let (height, timestamp, block_hash, is_instant_send, is_chain_locked) =
-                extract_context_fields(&status);
+                extract_context_fields(&record.context);
             SpvEvent::TransactionReceived {
-                txid: txid.to_byte_array(),
-                amount,
-                addresses: addresses.iter().map(|a| a.to_string()).collect(),
+                txid: record.txid.to_byte_array(),
+                amount: record.net_amount,
+                addresses: Vec::new(),
                 height,
                 timestamp,
                 block_hash,
@@ -698,7 +692,6 @@ fn map_wallet_event(event: WalletEvent) -> SpvEvent {
             }
         }
         WalletEvent::TransactionStatusChanged { txid, status, .. } => {
-            use dashcore::hashes::Hash;
             let (height, timestamp, block_hash, is_instant_send, is_chain_locked) =
                 extract_context_fields(&status);
             SpvEvent::TransactionReceived {
@@ -731,10 +724,9 @@ fn map_wallet_event(event: WalletEvent) -> SpvEvent {
 fn extract_context_fields(
     ctx: &TransactionContext,
 ) -> (Option<u32>, Option<u64>, Option<[u8; 32]>, bool, bool) {
-    use dashcore::hashes::Hash;
     match ctx {
         TransactionContext::Mempool => (None, None, None, false, false),
-        TransactionContext::InstantSend => (None, None, None, true, false),
+        TransactionContext::InstantSend(_) => (None, None, None, true, false),
         TransactionContext::InBlock(info) => (
             Some(info.height()),
             Some(info.timestamp() as u64),
@@ -758,13 +750,18 @@ mod tests {
 
     use dash_spv::network::NetworkEvent;
     use dash_spv::sync::{ManagerIdentifier, SyncEvent};
+    use dashcore::blockdata::transaction::Transaction;
     use dashcore::bls_sig_utils::BLSSignature;
     use dashcore::ephemerealdata::chain_lock::ChainLock;
     use dashcore::ephemerealdata::instant_lock::InstantLock;
     use dashcore::hashes::Hash;
     use dashcore::{Address, BlockHash, PublicKey, Txid};
+    use key_wallet::managed_account::transaction_record::{
+        TransactionDirection as RecordDirection, TransactionRecord,
+    };
     use key_wallet::transaction_checking::TransactionContext;
     use key_wallet::transaction_checking::transaction_context::BlockInfo;
+    use key_wallet::transaction_checking::transaction_router::TransactionType;
     use key_wallet_manager::WalletEvent;
 
     use super::*;
@@ -804,8 +801,9 @@ mod tests {
 
     #[test]
     fn extract_context_instant_send() {
+        let is_lock = InstantLock::default();
         let (height, timestamp, block_hash, is, cl) =
-            extract_context_fields(&TransactionContext::InstantSend);
+            extract_context_fields(&TransactionContext::InstantSend(is_lock));
         assert_eq!(height, None);
         assert_eq!(timestamp, None);
         assert_eq!(block_hash, None);
@@ -1039,21 +1037,27 @@ mod tests {
 
     #[test]
     fn map_wallet_event_transaction_received() {
-        let txid = Txid::all_zeros();
+        let tx = Transaction::dummy_empty();
+        let txid = tx.txid();
+        let record = TransactionRecord::new(
+            tx,
+            TransactionContext::Mempool,
+            TransactionType::Standard,
+            RecordDirection::Incoming,
+            Vec::new(),
+            Vec::new(),
+            50000,
+        );
         let event = WalletEvent::TransactionReceived {
             wallet_id: [0; 32],
-            status: TransactionContext::Mempool,
             account_index: 0,
-            txid,
-            amount: 50000,
-            addresses: vec![test_address()],
+            record: Box::new(record),
         };
         let mapped = map_wallet_event(event);
         match mapped {
             SpvEvent::TransactionReceived {
                 txid: mapped_txid,
                 amount,
-                addresses,
                 height,
                 is_instant_send,
                 is_chain_locked,
@@ -1061,7 +1065,6 @@ mod tests {
             } => {
                 assert_eq!(mapped_txid, txid.to_byte_array());
                 assert_eq!(amount, 50000);
-                assert_eq!(addresses.len(), 1);
                 assert_eq!(height, None);
                 assert!(!is_instant_send);
                 assert!(!is_chain_locked);

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -1150,10 +1150,26 @@ mod tests {
         let addr_b = Address::p2pkh(&pk_b, Network::Testnet);
 
         let input_details = vec![
-            InputDetail { index: 0, value: 1000, address: addr_a.clone() },
-            InputDetail { index: 1, value: 2000, address: addr_a.clone() },
-            InputDetail { index: 2, value: 3000, address: addr_b.clone() },
-            InputDetail { index: 3, value: 4000, address: addr_b.clone() },
+            InputDetail {
+                index: 0,
+                value: 1000,
+                address: addr_a.clone(),
+            },
+            InputDetail {
+                index: 1,
+                value: 2000,
+                address: addr_a.clone(),
+            },
+            InputDetail {
+                index: 2,
+                value: 3000,
+                address: addr_b.clone(),
+            },
+            InputDetail {
+                index: 3,
+                value: 4000,
+                address: addr_b.clone(),
+            },
         ];
 
         let tx = Transaction::dummy_empty();

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -378,6 +378,7 @@ impl SpvBackend for NativeBackend {
                 let is_instant_send = matches!(r.context, TransactionContext::InstantSend(_));
                 let is_chain_locked =
                     matches!(r.context, TransactionContext::InChainLockedBlock(_));
+                let addresses = extract_record_addresses(r);
                 TransactionInfo {
                     txid: r.txid,
                     amount: r.net_amount,
@@ -385,7 +386,7 @@ impl SpvBackend for NativeBackend {
                     timestamp: block_info.map_or(0, |i| i.timestamp() as u64),
                     height: block_info.map(|i| i.height()),
                     fee: r.fee,
-                    addresses: Vec::new(),
+                    addresses,
                     block_hash: block_info.map(|i| i.block_hash()),
                     is_instant_send,
                     is_chain_locked,
@@ -680,10 +681,11 @@ fn map_wallet_event(event: WalletEvent) -> SpvEvent {
         } => {
             let (height, timestamp, block_hash, is_instant_send, is_chain_locked) =
                 extract_context_fields(&record.context);
+            let addresses = extract_record_addresses(&record);
             SpvEvent::TransactionReceived {
                 txid: record.txid.to_byte_array(),
                 amount: record.net_amount,
-                addresses: Vec::new(),
+                addresses,
                 height,
                 timestamp,
                 block_hash,
@@ -718,6 +720,19 @@ fn map_wallet_event(event: WalletEvent) -> SpvEvent {
             locked,
         )),
     }
+}
+
+/// Extract unique addresses from a transaction record's input details.
+fn extract_record_addresses(
+    record: &key_wallet::managed_account::transaction_record::TransactionRecord,
+) -> Vec<String> {
+    let mut addrs: Vec<String> = record
+        .input_details
+        .iter()
+        .map(|d| d.address.to_string())
+        .collect();
+    addrs.dedup();
+    addrs
 }
 
 /// Extract UI-relevant fields from a `TransactionContext`.
@@ -1058,6 +1073,7 @@ mod tests {
             SpvEvent::TransactionReceived {
                 txid: mapped_txid,
                 amount,
+                addresses,
                 height,
                 is_instant_send,
                 is_chain_locked,
@@ -1065,6 +1081,7 @@ mod tests {
             } => {
                 assert_eq!(mapped_txid, txid.to_byte_array());
                 assert_eq!(amount, 50000);
+                assert!(addresses.is_empty());
                 assert_eq!(height, None);
                 assert!(!is_instant_send);
                 assert!(!is_chain_locked);

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -731,6 +731,7 @@ fn extract_record_addresses(
         .iter()
         .map(|d| d.address.to_string())
         .collect();
+    addrs.sort();
     addrs.dedup();
     addrs
 }


### PR DESCRIPTION
## Summary
- Update all `rust-dashcore` dependencies from `#09228787` to `#20983fa8` (latest `feat/dash-spv-wallet`)
- Fix `WalletEvent::TransactionReceived` destructuring for new `TransactionRecord`-based structure
- Fix `TransactionContext::InstantSend(_)` pattern matches (now carries `InstantLock` data)
- Remove inline `use` statements moved to module top

Closes #139