### PR TITLE
refactor: clean up transaction data model with upstream types

### DIFF
--- a/src/backend/events.rs
+++ b/src/backend/events.rs
@@ -1,65 +1,30 @@
 use tokio::sync::broadcast;
 
-use super::types::{
-    ManagerIdentifier, SyncProgress, TransactionDirection, TransactionType, WalletCoreBalance,
-};
+use super::types::{ManagerIdentifier, SyncProgress, TransactionInfo, WalletCoreBalance};
 
 /// Events emitted by the SPV backend.
 #[derive(Debug, Clone, PartialEq)]
 pub enum SpvEvent {
     // Sync events
     SyncProgressUpdated(Box<SyncProgress>),
-    SyncStarted {
-        manager: ManagerIdentifier,
-    },
-    HeadersSynced {
-        tip_height: u32,
-    },
-    FiltersSynced {
-        tip_height: u32,
-    },
-    BlockProcessed {
-        height: u32,
-        new_addresses: u32,
-    },
-    SyncComplete {
-        tip_height: u32,
-        cycle: u32,
-    },
+    SyncStarted { manager: ManagerIdentifier },
+    HeadersSynced { tip_height: u32 },
+    FiltersSynced { tip_height: u32 },
+    BlockProcessed { height: u32, new_addresses: u32 },
+    SyncComplete { tip_height: u32, cycle: u32 },
 
     // Network events
     PeerConnected(String),
     PeerDisconnected(String),
-    PeersUpdated {
-        count: u32,
-        best_height: u32,
-    },
+    PeersUpdated { count: u32, best_height: u32 },
 
     // Wallet events
-    TransactionReceived {
-        txid: [u8; 32],
-        amount: i64,
-        direction: TransactionDirection,
-        transaction_type: TransactionType,
-        addresses: Vec<String>,
-        height: Option<u32>,
-        timestamp: Option<u64>,
-        block_hash: Option<[u8; 32]>,
-        is_instant_send: bool,
-        is_chain_locked: bool,
-        label: Option<String>,
-    },
+    TransactionReceived(Box<TransactionInfo>),
     BalanceUpdated(WalletCoreBalance),
 
     // Validation events
-    ChainLockReceived {
-        height: u32,
-        validated: bool,
-    },
-    InstantLockReceived {
-        txid: [u8; 32],
-        validated: bool,
-    },
+    ChainLockReceived { height: u32, validated: bool },
+    InstantLockReceived { txid: [u8; 32], validated: bool },
 
     // Errors
     Error(String),

--- a/src/backend/events.rs
+++ b/src/backend/events.rs
@@ -1,6 +1,8 @@
 use tokio::sync::broadcast;
 
-use super::types::{ManagerIdentifier, SyncProgress, WalletCoreBalance};
+use super::types::{
+    ManagerIdentifier, SyncProgress, TransactionDirection, TransactionType, WalletCoreBalance,
+};
 
 /// Events emitted by the SPV backend.
 #[derive(Debug, Clone, PartialEq)]
@@ -37,12 +39,15 @@ pub enum SpvEvent {
     TransactionReceived {
         txid: [u8; 32],
         amount: i64,
+        direction: TransactionDirection,
+        transaction_type: TransactionType,
         addresses: Vec<String>,
         height: Option<u32>,
         timestamp: Option<u64>,
         block_hash: Option<[u8; 32]>,
         is_instant_send: bool,
         is_chain_locked: bool,
+        label: Option<String>,
     },
     BalanceUpdated(WalletCoreBalance),
 

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1643,3 +1643,74 @@ fn extract_ffi_input_addresses(record: &FFITransactionRecord) -> Vec<String> {
     addrs.dedup();
     addrs
 }
+
+#[cfg(test)]
+mod tests {
+    use key_wallet_ffi::types::{FFITransactionDirection, FFITransactionType};
+
+    use super::*;
+
+    #[test]
+    fn ffi_direction_to_direction_maps_all_variants() {
+        assert_eq!(
+            ffi_direction_to_direction(FFITransactionDirection::Incoming),
+            TransactionDirection::Incoming,
+        );
+        assert_eq!(
+            ffi_direction_to_direction(FFITransactionDirection::Outgoing),
+            TransactionDirection::Outgoing,
+        );
+        assert_eq!(
+            ffi_direction_to_direction(FFITransactionDirection::Internal),
+            TransactionDirection::Internal,
+        );
+        assert_eq!(
+            ffi_direction_to_direction(FFITransactionDirection::CoinJoin),
+            TransactionDirection::CoinJoin,
+        );
+    }
+
+    #[test]
+    fn ffi_type_to_type_maps_all_variants() {
+        assert_eq!(
+            ffi_type_to_type(FFITransactionType::Standard),
+            TransactionType::Standard,
+        );
+        assert_eq!(
+            ffi_type_to_type(FFITransactionType::CoinJoin),
+            TransactionType::CoinJoin,
+        );
+        assert_eq!(
+            ffi_type_to_type(FFITransactionType::ProviderRegistration),
+            TransactionType::ProviderRegistration,
+        );
+        assert_eq!(
+            ffi_type_to_type(FFITransactionType::ProviderUpdateRegistrar),
+            TransactionType::ProviderUpdateRegistrar,
+        );
+        assert_eq!(
+            ffi_type_to_type(FFITransactionType::ProviderUpdateService),
+            TransactionType::ProviderUpdateService,
+        );
+        assert_eq!(
+            ffi_type_to_type(FFITransactionType::ProviderUpdateRevocation),
+            TransactionType::ProviderUpdateRevocation,
+        );
+        assert_eq!(
+            ffi_type_to_type(FFITransactionType::AssetLock),
+            TransactionType::AssetLock,
+        );
+        assert_eq!(
+            ffi_type_to_type(FFITransactionType::AssetUnlock),
+            TransactionType::AssetUnlock,
+        );
+        assert_eq!(
+            ffi_type_to_type(FFITransactionType::Coinbase),
+            TransactionType::Coinbase,
+        );
+        assert_eq!(
+            ffi_type_to_type(FFITransactionType::Ignored),
+            TransactionType::Ignored,
+        );
+    }
+}

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use dash_spv::sync::{
     BlockHeadersProgress, BlocksProgress, ChainLockProgress, FilterHeadersProgress,
@@ -1480,8 +1481,8 @@ extern "C" fn on_transaction_received(
     // Safety: label is a valid C string for the duration of the callback.
     let label = unsafe { extract_ffi_label(r.label) };
 
-    let fallback_timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
+    let fallback_timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
 

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1494,31 +1494,39 @@ extern "C" fn on_transaction_received(
         if s.is_empty() { None } else { Some(s) }
     };
 
-    let _ = ctx.event_tx.send(SpvEvent::TransactionReceived {
-        txid: r.txid,
-        amount: r.net_amount,
-        direction: ffi_direction_to_direction(r.direction),
-        transaction_type: ffi_type_to_type(r.transaction_type),
-        addresses,
-        height: if has_block {
-            Some(block_info.height)
-        } else {
-            None
-        },
-        timestamp: if has_block {
-            Some(block_info.timestamp as u64)
-        } else {
-            None
-        },
-        block_hash: if has_block {
-            Some(block_info.block_hash)
-        } else {
-            None
-        },
-        is_instant_send,
-        is_chain_locked,
-        label,
-    });
+    let fallback_timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let _ = ctx
+        .event_tx
+        .send(SpvEvent::TransactionReceived(Box::new(TransactionInfo {
+            txid: dashcore::Txid::from_byte_array(r.txid),
+            amount: r.net_amount,
+            direction: ffi_direction_to_direction(r.direction),
+            transaction_type: ffi_type_to_type(r.transaction_type),
+            timestamp: if has_block {
+                block_info.timestamp as u64
+            } else {
+                fallback_timestamp
+            },
+            height: if has_block {
+                Some(block_info.height)
+            } else {
+                None
+            },
+            fee: None,
+            addresses,
+            block_hash: if has_block {
+                Some(dashcore::BlockHash::from_byte_array(block_info.block_hash))
+            } else {
+                None
+            },
+            is_instant_send,
+            is_chain_locked,
+            label,
+        })));
 }
 
 extern "C" fn on_balance_updated(

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1502,7 +1502,7 @@ extern "C" fn on_transaction_received(
             } else {
                 None
             },
-            fee: None,
+            fee: if r.fee > 0 { Some(r.fee) } else { None },
             addresses,
             block_hash: if has_block {
                 Some(dashcore::BlockHash::from_byte_array(block_info.block_hash))

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1611,7 +1611,10 @@ unsafe fn extract_ffi_label(ptr: *const c_char) -> Option<String> {
     if ptr.is_null() {
         return None;
     }
-    let s = CStr::from_ptr(ptr).to_string_lossy().into_owned();
+    // Safety: caller guarantees `ptr` is a valid, nul-terminated C string.
+    let s = unsafe { CStr::from_ptr(ptr) }
+        .to_string_lossy()
+        .into_owned();
     if s.is_empty() { None } else { Some(s) }
 }
 
@@ -1646,6 +1649,9 @@ fn extract_ffi_input_addresses(record: &FFITransactionRecord) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::CString;
+    use std::ptr;
+
     use key_wallet_ffi::types::{FFITransactionDirection, FFITransactionType};
 
     use super::*;
@@ -1712,5 +1718,25 @@ mod tests {
             ffi_type_to_type(FFITransactionType::Ignored),
             TransactionType::Ignored,
         );
+    }
+
+    #[test]
+    fn extract_ffi_label_null_returns_none() {
+        let result = unsafe { extract_ffi_label(ptr::null()) };
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn extract_ffi_label_empty_returns_none() {
+        let s = CString::new("").unwrap();
+        let result = unsafe { extract_ffi_label(s.as_ptr()) };
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn extract_ffi_label_valid_returns_some() {
+        let s = CString::new("coffee payment").unwrap();
+        let result = unsafe { extract_ffi_label(s.as_ptr()) };
+        assert_eq!(result, Some("coffee payment".to_string()));
     }
 }

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -49,8 +49,10 @@ use key_wallet_ffi::managed_wallet::{
     managed_wallet_get_next_bip44_change_address, managed_wallet_info_free,
 };
 use key_wallet_ffi::mnemonic::{mnemonic_free, mnemonic_generate};
-use key_wallet_ffi::types::FFIAccountType;
-use key_wallet_ffi::types::{FFINetwork, FFITransactionContextType};
+use key_wallet_ffi::types::{
+    FFIAccountType, FFINetwork, FFITransactionContextType, FFITransactionDirection,
+    FFITransactionType,
+};
 use key_wallet_ffi::utxo::{managed_wallet_get_utxos, utxo_array_free};
 use key_wallet_ffi::wallet::wallet_free_const;
 use key_wallet_ffi::wallet_manager::{
@@ -64,7 +66,8 @@ use super::error::{BackendError, BackendResult};
 use super::events::{EventReceiver, EventSender, SpvEvent, event_channel};
 use super::r#trait::SpvBackend;
 use super::types::{
-    Network, SyncProgress, TransactionDirection, TransactionInfo, WalletCoreBalance,
+    Network, SyncProgress, TransactionDirection, TransactionInfo, TransactionType,
+    WalletCoreBalance,
 };
 use crate::config::AppConfig;
 
@@ -584,12 +587,6 @@ impl SpvBackend for FfiBackend {
                 let records = unsafe { std::slice::from_raw_parts(txs_ptr, tx_count) };
 
                 for record in records {
-                    let direction = if record.net_amount >= 0 {
-                        TransactionDirection::Received
-                    } else {
-                        TransactionDirection::Sent
-                    };
-
                     let txid = dashcore::Txid::from_byte_array(record.txid);
                     let fee = if record.fee > 0 {
                         Some(record.fee)
@@ -608,10 +605,21 @@ impl SpvBackend for FfiBackend {
                         FFITransactionContextType::InChainLockedBlock
                     );
 
+                    let label = if record.label.is_null() {
+                        None
+                    } else {
+                        // Safety: label is a valid C string for the lifetime of the record.
+                        let s = unsafe { CStr::from_ptr(record.label) }
+                            .to_string_lossy()
+                            .into_owned();
+                        if s.is_empty() { None } else { Some(s) }
+                    };
+
                     transactions.push(TransactionInfo {
                         txid,
                         amount: record.net_amount,
-                        direction,
+                        direction: ffi_direction_to_direction(record.direction),
+                        transaction_type: ffi_type_to_type(record.transaction_type),
                         timestamp: if has_block {
                             block_info.timestamp as u64
                         } else {
@@ -631,6 +639,7 @@ impl SpvBackend for FfiBackend {
                         },
                         is_instant_send,
                         is_chain_locked,
+                        label,
                     });
                 }
 
@@ -1475,9 +1484,21 @@ extern "C" fn on_transaction_received(
 
     let addresses = extract_ffi_input_addresses(r);
 
+    let label = if r.label.is_null() {
+        None
+    } else {
+        // Safety: label is a valid C string for the duration of the callback.
+        let s = unsafe { CStr::from_ptr(r.label) }
+            .to_string_lossy()
+            .into_owned();
+        if s.is_empty() { None } else { Some(s) }
+    };
+
     let _ = ctx.event_tx.send(SpvEvent::TransactionReceived {
         txid: r.txid,
         amount: r.net_amount,
+        direction: ffi_direction_to_direction(r.direction),
+        transaction_type: ffi_type_to_type(r.transaction_type),
         addresses,
         height: if has_block {
             Some(block_info.height)
@@ -1496,6 +1517,7 @@ extern "C" fn on_transaction_received(
         },
         is_instant_send,
         is_chain_locked,
+        label,
     });
 }
 
@@ -1558,6 +1580,30 @@ fn ffi_transaction_context_flags(ctx_type: FFITransactionContextType) -> (bool, 
         FFITransactionContextType::InstantSend => (true, false),
         FFITransactionContextType::InChainLockedBlock => (false, true),
         FFITransactionContextType::Mempool | FFITransactionContextType::InBlock => (false, false),
+    }
+}
+
+fn ffi_direction_to_direction(dir: FFITransactionDirection) -> TransactionDirection {
+    match dir {
+        FFITransactionDirection::Incoming => TransactionDirection::Incoming,
+        FFITransactionDirection::Outgoing => TransactionDirection::Outgoing,
+        FFITransactionDirection::Internal => TransactionDirection::Internal,
+        FFITransactionDirection::CoinJoin => TransactionDirection::CoinJoin,
+    }
+}
+
+fn ffi_type_to_type(tt: FFITransactionType) -> TransactionType {
+    match tt {
+        FFITransactionType::Standard => TransactionType::Standard,
+        FFITransactionType::CoinJoin => TransactionType::CoinJoin,
+        FFITransactionType::ProviderRegistration => TransactionType::ProviderRegistration,
+        FFITransactionType::ProviderUpdateRegistrar => TransactionType::ProviderUpdateRegistrar,
+        FFITransactionType::ProviderUpdateService => TransactionType::ProviderUpdateService,
+        FFITransactionType::ProviderUpdateRevocation => TransactionType::ProviderUpdateRevocation,
+        FFITransactionType::AssetLock => TransactionType::AssetLock,
+        FFITransactionType::AssetUnlock => TransactionType::AssetUnlock,
+        FFITransactionType::Coinbase => TransactionType::Coinbase,
+        FFITransactionType::Ignored => TransactionType::Ignored,
     }
 }
 

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -605,15 +605,8 @@ impl SpvBackend for FfiBackend {
                         FFITransactionContextType::InChainLockedBlock
                     );
 
-                    let label = if record.label.is_null() {
-                        None
-                    } else {
-                        // Safety: label is a valid C string for the lifetime of the record.
-                        let s = unsafe { CStr::from_ptr(record.label) }
-                            .to_string_lossy()
-                            .into_owned();
-                        if s.is_empty() { None } else { Some(s) }
-                    };
+                    // Safety: label is a valid C string for the lifetime of the record.
+                    let label = unsafe { extract_ffi_label(record.label) };
 
                     transactions.push(TransactionInfo {
                         txid,
@@ -1484,15 +1477,8 @@ extern "C" fn on_transaction_received(
 
     let addresses = extract_ffi_input_addresses(r);
 
-    let label = if r.label.is_null() {
-        None
-    } else {
-        // Safety: label is a valid C string for the duration of the callback.
-        let s = unsafe { CStr::from_ptr(r.label) }
-            .to_string_lossy()
-            .into_owned();
-        if s.is_empty() { None } else { Some(s) }
-    };
+    // Safety: label is a valid C string for the duration of the callback.
+    let label = unsafe { extract_ffi_label(r.label) };
 
     let fallback_timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -1613,6 +1599,20 @@ fn ffi_type_to_type(tt: FFITransactionType) -> TransactionType {
         FFITransactionType::Coinbase => TransactionType::Coinbase,
         FFITransactionType::Ignored => TransactionType::Ignored,
     }
+}
+
+/// Extract an optional label string from a C string pointer.
+///
+/// # Safety
+///
+/// `ptr` must be null or point to a valid, nul-terminated C string for the
+/// duration of the call.
+unsafe fn extract_ffi_label(ptr: *const c_char) -> Option<String> {
+    if ptr.is_null() {
+        return None;
+    }
+    let s = CStr::from_ptr(ptr).to_string_lossy().into_owned();
+    if s.is_empty() { None } else { Some(s) }
 }
 
 /// Extract addresses from an `FFITransactionRecord`'s input details.

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -571,6 +571,8 @@ mod tests {
         let txs = vec![
             mock_transaction(0, TransactionDirection::Incoming, 100_000),
             mock_transaction(1, TransactionDirection::Outgoing, 50_000),
+            mock_transaction(2, TransactionDirection::Internal, 10_000),
+            mock_transaction(3, TransactionDirection::CoinJoin, 10_000),
         ];
         let backend = MockBackend::builder(Network::Mainnet)
             .with_transactions(txs.clone())
@@ -578,9 +580,15 @@ mod tests {
         backend.create_wallet(TEST_MNEMONIC_12).await.unwrap();
 
         let result = backend.get_transactions().unwrap();
-        assert_eq!(result.len(), 2);
+        assert_eq!(result.len(), 4);
         assert_eq!(result[0].direction, TransactionDirection::Incoming);
+        assert_eq!(result[0].amount, 100_000);
         assert_eq!(result[1].direction, TransactionDirection::Outgoing);
+        assert_eq!(result[1].amount, -50_000);
+        assert_eq!(result[2].direction, TransactionDirection::Internal);
+        assert_eq!(result[2].amount, 10_000);
+        assert_eq!(result[3].direction, TransactionDirection::CoinJoin);
+        assert_eq!(result[3].amount, -10_000);
     }
 
     #[tokio::test]

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -10,7 +10,8 @@ use super::error::{BackendError, BackendResult};
 use super::events::{EventReceiver, EventSender, SpvEvent};
 use super::r#trait::SpvBackend;
 use super::types::{
-    Network, SyncProgress, TransactionDirection, TransactionInfo, WalletCoreBalance,
+    Network, SyncProgress, TransactionDirection, TransactionInfo, TransactionType,
+    WalletCoreBalance,
 };
 
 /// Builder for configuring a `MockBackend` instance.
@@ -231,7 +232,8 @@ impl SpvBackend for MockBackend {
         let record = TransactionInfo {
             txid: dashcore::Txid::from_byte_array(txid_bytes),
             amount: -(amount as i64),
-            direction: TransactionDirection::Sent,
+            direction: TransactionDirection::Outgoing,
+            transaction_type: TransactionType::Standard,
             timestamp: 1700000000,
             height: None,
             fee: None,
@@ -239,6 +241,7 @@ impl SpvBackend for MockBackend {
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: false,
+            label: None,
         };
 
         self.transactions.lock().unwrap().push(record);
@@ -246,12 +249,15 @@ impl SpvBackend for MockBackend {
         self.emit(SpvEvent::TransactionReceived {
             txid: txid_bytes,
             amount: -(amount as i64),
+            direction: TransactionDirection::Outgoing,
+            transaction_type: TransactionType::Standard,
             addresses: vec![address.to_string()],
             height: None,
             timestamp: None,
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: false,
+            label: None,
         });
 
         Ok(txid_bytes)
@@ -290,10 +296,11 @@ pub fn mock_transaction(
     TransactionInfo {
         txid: dashcore::Txid::from_byte_array(mock_txid(index)),
         amount: match direction {
-            TransactionDirection::Sent => -(amount as i64),
-            TransactionDirection::Received => amount as i64,
+            TransactionDirection::Outgoing => -(amount as i64),
+            _ => amount as i64,
         },
         direction,
+        transaction_type: TransactionType::Standard,
         timestamp: 1700000000 + (index as u64 * 600),
         height: Some(1000 + index),
         fee: None,
@@ -301,6 +308,7 @@ pub fn mock_transaction(
         block_hash: None,
         is_instant_send: false,
         is_chain_locked: false,
+        label: None,
     }
 }
 
@@ -430,7 +438,7 @@ mod tests {
 
         let txs = backend.get_transactions().unwrap();
         assert_eq!(txs.len(), 1);
-        assert_eq!(txs[0].direction, TransactionDirection::Sent);
+        assert_eq!(txs[0].direction, TransactionDirection::Outgoing);
         assert_eq!(txs[0].amount, -250_000);
     }
 
@@ -573,8 +581,8 @@ mod tests {
     #[tokio::test]
     async fn builder_with_transactions() {
         let txs = vec![
-            mock_transaction(0, TransactionDirection::Received, 100_000),
-            mock_transaction(1, TransactionDirection::Sent, 50_000),
+            mock_transaction(0, TransactionDirection::Incoming, 100_000),
+            mock_transaction(1, TransactionDirection::Outgoing, 50_000),
         ];
         let backend = MockBackend::builder(Network::Mainnet)
             .with_transactions(txs.clone())
@@ -583,8 +591,8 @@ mod tests {
 
         let result = backend.get_transactions().unwrap();
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0].direction, TransactionDirection::Received);
-        assert_eq!(result[1].direction, TransactionDirection::Sent);
+        assert_eq!(result[0].direction, TransactionDirection::Incoming);
+        assert_eq!(result[1].direction, TransactionDirection::Outgoing);
     }
 
     #[tokio::test]

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -244,22 +244,9 @@ impl SpvBackend for MockBackend {
             label: None,
         };
 
-        self.transactions.lock().unwrap().push(record);
+        self.transactions.lock().unwrap().push(record.clone());
         self.emit(SpvEvent::BalanceUpdated(new_balance));
-        self.emit(SpvEvent::TransactionReceived(Box::new(TransactionInfo {
-            txid: dashcore::Txid::from_byte_array(txid_bytes),
-            amount: -(amount as i64),
-            direction: TransactionDirection::Outgoing,
-            transaction_type: TransactionType::Standard,
-            timestamp: 1700000000,
-            height: None,
-            fee: None,
-            addresses: vec![address.to_string()],
-            block_hash: None,
-            is_instant_send: false,
-            is_chain_locked: false,
-            label: None,
-        })));
+        self.emit(SpvEvent::TransactionReceived(Box::new(record)));
 
         Ok(txid_bytes)
     }

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -246,19 +246,20 @@ impl SpvBackend for MockBackend {
 
         self.transactions.lock().unwrap().push(record);
         self.emit(SpvEvent::BalanceUpdated(new_balance));
-        self.emit(SpvEvent::TransactionReceived {
-            txid: txid_bytes,
+        self.emit(SpvEvent::TransactionReceived(Box::new(TransactionInfo {
+            txid: dashcore::Txid::from_byte_array(txid_bytes),
             amount: -(amount as i64),
             direction: TransactionDirection::Outgoing,
             transaction_type: TransactionType::Standard,
-            addresses: vec![address.to_string()],
+            timestamp: 1700000000,
             height: None,
-            timestamp: None,
+            fee: None,
+            addresses: vec![address.to_string()],
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: false,
             label: None,
-        });
+        })));
 
         Ok(txid_bytes)
     }
@@ -561,7 +562,7 @@ mod tests {
         assert!(matches!(event1, SpvEvent::BalanceUpdated(_)));
 
         let event2 = rx.try_recv().unwrap();
-        assert!(matches!(event2, SpvEvent::TransactionReceived { .. }));
+        assert!(matches!(event2, SpvEvent::TransactionReceived(_)));
     }
 
     #[tokio::test]

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -284,8 +284,8 @@ pub fn mock_transaction(
     TransactionInfo {
         txid: dashcore::Txid::from_byte_array(mock_txid(index)),
         amount: match direction {
-            TransactionDirection::Outgoing => -(amount as i64),
-            _ => amount as i64,
+            TransactionDirection::Outgoing | TransactionDirection::CoinJoin => -(amount as i64),
+            TransactionDirection::Incoming | TransactionDirection::Internal => amount as i64,
         },
         direction,
         transaction_type: TransactionType::Standard,

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -370,7 +370,7 @@ impl SpvBackend for NativeBackend {
 
         let mut transactions: Vec<TransactionInfo> = records
             .into_iter()
-            .map(TransactionInfo::from_record)
+            .map(|r| TransactionInfo::from_record(r, 0))
             .collect();
 
         // Sort: unconfirmed first, then by timestamp descending
@@ -657,7 +657,16 @@ fn map_wallet_event(event: WalletEvent) -> SpvEvent {
             wallet_id: _,
             account_index: _,
             record,
-        } => SpvEvent::TransactionReceived(Box::new(TransactionInfo::from_record(&record))),
+        } => {
+            let fallback_timestamp = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            SpvEvent::TransactionReceived(Box::new(TransactionInfo::from_record(
+                &record,
+                fallback_timestamp,
+            )))
+        }
         WalletEvent::TransactionStatusChanged { txid, status, .. } => {
             let (height, timestamp, block_hash, is_instant_send, is_chain_locked) =
                 extract_context_fields(&status);
@@ -697,14 +706,15 @@ fn map_wallet_event(event: WalletEvent) -> SpvEvent {
 
 impl TransactionInfo {
     /// Build a `TransactionInfo` from a wallet `TransactionRecord`.
-    fn from_record(record: &TransactionRecord) -> Self {
+    ///
+    /// `fallback_timestamp` is used when the transaction context carries no
+    /// timestamp (mempool / instant-send).  Pass `0` for cold-start loads
+    /// (renders as "Pending") or the current unix time for live events
+    /// (renders as "just now").
+    fn from_record(record: &TransactionRecord, fallback_timestamp: u64) -> Self {
         let (height, timestamp, block_hash, is_instant_send, is_chain_locked) =
             extract_context_fields(&record.context);
         let addresses = extract_record_addresses(record);
-        let fallback_timestamp = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
         TransactionInfo {
             txid: record.txid,
             amount: record.net_amount,

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeSet;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
-
-use std::path::PathBuf;
+use std::time::SystemTime;
 
 use dash_spv::client::EventHandler;
 use dash_spv::network::NetworkEvent;
@@ -14,6 +14,7 @@ use dash_spv::sync::SyncEvent;
 use dash_spv::{ClientConfig, DashSpvClient, MempoolStrategy};
 use dashcore::hashes::Hash;
 use key_wallet::managed_account::managed_account_type::ManagedAccountType;
+use key_wallet::managed_account::transaction_record::TransactionRecord;
 use key_wallet::mnemonic::Language;
 use key_wallet::transaction_checking::TransactionContext;
 use key_wallet::wallet::initialization::WalletAccountCreationOptions;
@@ -369,27 +370,7 @@ impl SpvBackend for NativeBackend {
 
         let mut transactions: Vec<TransactionInfo> = records
             .into_iter()
-            .map(|r| {
-                let block_info = r.context.block_info();
-                let is_instant_send = matches!(r.context, TransactionContext::InstantSend(_));
-                let is_chain_locked =
-                    matches!(r.context, TransactionContext::InChainLockedBlock(_));
-                let addresses = extract_record_addresses(r);
-                TransactionInfo {
-                    txid: r.txid,
-                    amount: r.net_amount,
-                    direction: r.direction,
-                    transaction_type: r.transaction_type,
-                    timestamp: block_info.map_or(0, |i| i.timestamp() as u64),
-                    height: block_info.map(|i| i.height()),
-                    fee: r.fee,
-                    addresses,
-                    block_hash: block_info.map(|i| i.block_hash()),
-                    is_instant_send,
-                    is_chain_locked,
-                    label: r.label.clone(),
-                }
-            })
+            .map(TransactionInfo::from_record)
             .collect();
 
         // Sort: unconfirmed first, then by timestamp descending
@@ -676,34 +657,12 @@ fn map_wallet_event(event: WalletEvent) -> SpvEvent {
             wallet_id: _,
             account_index: _,
             record,
-        } => {
-            let (height, timestamp, block_hash, is_instant_send, is_chain_locked) =
-                extract_context_fields(&record.context);
-            let addresses = extract_record_addresses(&record);
-            let fallback_timestamp = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-            SpvEvent::TransactionReceived(Box::new(TransactionInfo {
-                txid: record.txid,
-                amount: record.net_amount,
-                direction: record.direction,
-                transaction_type: record.transaction_type,
-                timestamp: timestamp.unwrap_or(fallback_timestamp),
-                height,
-                fee: None,
-                addresses,
-                block_hash: block_hash.map(dashcore::BlockHash::from_byte_array),
-                is_instant_send,
-                is_chain_locked,
-                label: record.label,
-            }))
-        }
+        } => SpvEvent::TransactionReceived(Box::new(TransactionInfo::from_record(&record))),
         WalletEvent::TransactionStatusChanged { txid, status, .. } => {
             let (height, timestamp, block_hash, is_instant_send, is_chain_locked) =
                 extract_context_fields(&status);
-            let fallback_timestamp = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
+            let fallback_timestamp = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs();
             SpvEvent::TransactionReceived(Box::new(TransactionInfo {
@@ -736,10 +695,35 @@ fn map_wallet_event(event: WalletEvent) -> SpvEvent {
     }
 }
 
+impl TransactionInfo {
+    /// Build a `TransactionInfo` from a wallet `TransactionRecord`.
+    fn from_record(record: &TransactionRecord) -> Self {
+        let (height, timestamp, block_hash, is_instant_send, is_chain_locked) =
+            extract_context_fields(&record.context);
+        let addresses = extract_record_addresses(record);
+        let fallback_timestamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        TransactionInfo {
+            txid: record.txid,
+            amount: record.net_amount,
+            direction: record.direction,
+            transaction_type: record.transaction_type,
+            timestamp: timestamp.unwrap_or(fallback_timestamp),
+            height,
+            fee: record.fee,
+            addresses,
+            block_hash: block_hash.map(dashcore::BlockHash::from_byte_array),
+            is_instant_send,
+            is_chain_locked,
+            label: record.label.clone(),
+        }
+    }
+}
+
 /// Extract unique addresses from a transaction record's input details.
-fn extract_record_addresses(
-    record: &key_wallet::managed_account::transaction_record::TransactionRecord,
-) -> Vec<String> {
+fn extract_record_addresses(record: &TransactionRecord) -> Vec<String> {
     let mut addrs: Vec<String> = record
         .input_details
         .iter()

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -1086,6 +1086,8 @@ mod tests {
             SpvEvent::TransactionReceived(info) => {
                 assert_eq!(info.txid, txid);
                 assert_eq!(info.amount, 50000);
+                assert_eq!(info.direction, TransactionDirection::Incoming);
+                assert_eq!(info.transaction_type, TransactionType::Standard);
                 assert!(info.addresses.is_empty());
                 assert_eq!(info.height, None);
                 assert!(!info.is_instant_send);

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -680,36 +680,46 @@ fn map_wallet_event(event: WalletEvent) -> SpvEvent {
             let (height, timestamp, block_hash, is_instant_send, is_chain_locked) =
                 extract_context_fields(&record.context);
             let addresses = extract_record_addresses(&record);
-            SpvEvent::TransactionReceived {
-                txid: record.txid.to_byte_array(),
+            let fallback_timestamp = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            SpvEvent::TransactionReceived(Box::new(TransactionInfo {
+                txid: record.txid,
                 amount: record.net_amount,
                 direction: record.direction,
                 transaction_type: record.transaction_type,
-                addresses,
+                timestamp: timestamp.unwrap_or(fallback_timestamp),
                 height,
-                timestamp,
-                block_hash,
+                fee: None,
+                addresses,
+                block_hash: block_hash.map(dashcore::BlockHash::from_byte_array),
                 is_instant_send,
                 is_chain_locked,
                 label: record.label,
-            }
+            }))
         }
         WalletEvent::TransactionStatusChanged { txid, status, .. } => {
             let (height, timestamp, block_hash, is_instant_send, is_chain_locked) =
                 extract_context_fields(&status);
-            SpvEvent::TransactionReceived {
-                txid: txid.to_byte_array(),
+            let fallback_timestamp = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            SpvEvent::TransactionReceived(Box::new(TransactionInfo {
+                txid,
                 amount: 0,
                 direction: TransactionDirection::Incoming,
                 transaction_type: TransactionType::Standard,
-                addresses: Vec::new(),
+                timestamp: timestamp.unwrap_or(fallback_timestamp),
                 height,
-                timestamp,
-                block_hash,
+                fee: None,
+                addresses: Vec::new(),
+                block_hash: block_hash.map(dashcore::BlockHash::from_byte_array),
                 is_instant_send,
                 is_chain_locked,
                 label: None,
-            }
+            }))
         }
         WalletEvent::BalanceUpdated {
             spendable,
@@ -1073,21 +1083,13 @@ mod tests {
         };
         let mapped = map_wallet_event(event);
         match mapped {
-            SpvEvent::TransactionReceived {
-                txid: mapped_txid,
-                amount,
-                addresses,
-                height,
-                is_instant_send,
-                is_chain_locked,
-                ..
-            } => {
-                assert_eq!(mapped_txid, txid.to_byte_array());
-                assert_eq!(amount, 50000);
-                assert!(addresses.is_empty());
-                assert_eq!(height, None);
-                assert!(!is_instant_send);
-                assert!(!is_chain_locked);
+            SpvEvent::TransactionReceived(info) => {
+                assert_eq!(info.txid, txid);
+                assert_eq!(info.amount, 50000);
+                assert!(info.addresses.is_empty());
+                assert_eq!(info.height, None);
+                assert!(!info.is_instant_send);
+                assert!(!info.is_chain_locked);
             }
             other => panic!("expected TransactionReceived, got {:?}", other),
         }
@@ -1107,17 +1109,11 @@ mod tests {
         };
         let mapped = map_wallet_event(event);
         match mapped {
-            SpvEvent::TransactionReceived {
-                amount,
-                height,
-                timestamp,
-                is_chain_locked,
-                ..
-            } => {
-                assert_eq!(amount, 0);
-                assert_eq!(height, Some(300));
-                assert_eq!(timestamp, Some(1700000000));
-                assert!(!is_chain_locked);
+            SpvEvent::TransactionReceived(info) => {
+                assert_eq!(info.amount, 0);
+                assert_eq!(info.height, Some(300));
+                assert_eq!(info.timestamp, 1700000000);
+                assert!(!info.is_chain_locked);
             }
             other => panic!("expected TransactionReceived, got {:?}", other),
         }

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -1097,6 +1097,8 @@ mod tests {
         match mapped {
             SpvEvent::TransactionReceived(info) => {
                 assert_eq!(info.amount, 0);
+                assert_eq!(info.direction, TransactionDirection::Incoming);
+                assert_eq!(info.transaction_type, TransactionType::Standard);
                 assert_eq!(info.height, Some(300));
                 assert_eq!(info.timestamp, 1700000000);
                 assert!(!info.is_chain_locked);

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -1151,6 +1151,27 @@ mod tests {
 
         assert_eq!(info.timestamp, 1700000000);
         assert_eq!(info.height, Some(500));
+        assert_eq!(info.direction, TransactionDirection::Incoming);
+        assert_eq!(info.transaction_type, TransactionType::Standard);
+    }
+
+    #[test]
+    fn from_record_mempool_uses_fallback_timestamp() {
+        let tx = Transaction::dummy_empty();
+        let record = TransactionRecord::new(
+            tx,
+            TransactionContext::Mempool,
+            TransactionType::Standard,
+            TransactionDirection::Incoming,
+            Vec::new(),
+            Vec::new(),
+            10000,
+        );
+
+        let info = TransactionInfo::from_record(&record, 0);
+
+        assert_eq!(info.timestamp, 0);
+        assert_eq!(info.height, None);
     }
 
     #[test]

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -1134,6 +1134,26 @@ mod tests {
     }
 
     #[test]
+    fn from_record_in_block_uses_block_timestamp_over_fallback() {
+        let tx = Transaction::dummy_empty();
+        let block_hash = BlockHash::all_zeros();
+        let record = TransactionRecord::new(
+            tx,
+            TransactionContext::InBlock(BlockInfo::new(500, block_hash, 1700000000)),
+            TransactionType::Standard,
+            TransactionDirection::Incoming,
+            Vec::new(),
+            Vec::new(),
+            42000,
+        );
+
+        let info = TransactionInfo::from_record(&record, 9999999999);
+
+        assert_eq!(info.timestamp, 1700000000);
+        assert_eq!(info.height, Some(500));
+    }
+
+    #[test]
     fn extract_record_addresses_deduplicates() {
         let addr_a = test_address();
         // Create a distinct address using a different public key

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -33,7 +33,8 @@ use super::error::{BackendError, BackendResult};
 use super::events::{EventReceiver, EventSender, SpvEvent, event_channel};
 use super::r#trait::SpvBackend;
 use super::types::{
-    Network, SyncProgress, TransactionDirection, TransactionInfo, WalletCoreBalance,
+    Network, SyncProgress, TransactionDirection, TransactionInfo, TransactionType,
+    WalletCoreBalance,
 };
 use crate::config::AppConfig;
 
@@ -369,11 +370,6 @@ impl SpvBackend for NativeBackend {
         let mut transactions: Vec<TransactionInfo> = records
             .into_iter()
             .map(|r| {
-                let direction = if r.net_amount >= 0 {
-                    TransactionDirection::Received
-                } else {
-                    TransactionDirection::Sent
-                };
                 let block_info = r.context.block_info();
                 let is_instant_send = matches!(r.context, TransactionContext::InstantSend(_));
                 let is_chain_locked =
@@ -382,7 +378,8 @@ impl SpvBackend for NativeBackend {
                 TransactionInfo {
                     txid: r.txid,
                     amount: r.net_amount,
-                    direction,
+                    direction: r.direction,
+                    transaction_type: r.transaction_type,
                     timestamp: block_info.map_or(0, |i| i.timestamp() as u64),
                     height: block_info.map(|i| i.height()),
                     fee: r.fee,
@@ -390,6 +387,7 @@ impl SpvBackend for NativeBackend {
                     block_hash: block_info.map(|i| i.block_hash()),
                     is_instant_send,
                     is_chain_locked,
+                    label: r.label.clone(),
                 }
             })
             .collect();
@@ -685,12 +683,15 @@ fn map_wallet_event(event: WalletEvent) -> SpvEvent {
             SpvEvent::TransactionReceived {
                 txid: record.txid.to_byte_array(),
                 amount: record.net_amount,
+                direction: record.direction,
+                transaction_type: record.transaction_type,
                 addresses,
                 height,
                 timestamp,
                 block_hash,
                 is_instant_send,
                 is_chain_locked,
+                label: record.label,
             }
         }
         WalletEvent::TransactionStatusChanged { txid, status, .. } => {
@@ -699,12 +700,15 @@ fn map_wallet_event(event: WalletEvent) -> SpvEvent {
             SpvEvent::TransactionReceived {
                 txid: txid.to_byte_array(),
                 amount: 0,
+                direction: TransactionDirection::Incoming,
+                transaction_type: TransactionType::Standard,
                 addresses: Vec::new(),
                 height,
                 timestamp,
                 block_hash,
                 is_instant_send,
                 is_chain_locked,
+                label: None,
             }
         }
         WalletEvent::BalanceUpdated {
@@ -772,9 +776,7 @@ mod tests {
     use dashcore::ephemerealdata::instant_lock::InstantLock;
     use dashcore::hashes::Hash;
     use dashcore::{Address, BlockHash, PublicKey, Txid};
-    use key_wallet::managed_account::transaction_record::{
-        InputDetail, TransactionDirection as RecordDirection, TransactionRecord,
-    };
+    use key_wallet::managed_account::transaction_record::{InputDetail, TransactionRecord};
     use key_wallet::transaction_checking::TransactionContext;
     use key_wallet::transaction_checking::transaction_context::BlockInfo;
     use key_wallet::transaction_checking::transaction_router::TransactionType;
@@ -1059,7 +1061,7 @@ mod tests {
             tx,
             TransactionContext::Mempool,
             TransactionType::Standard,
-            RecordDirection::Incoming,
+            TransactionDirection::Incoming,
             Vec::new(),
             Vec::new(),
             50000,
@@ -1177,7 +1179,7 @@ mod tests {
             tx,
             TransactionContext::Mempool,
             TransactionType::Standard,
-            RecordDirection::Incoming,
+            TransactionDirection::Incoming,
             input_details,
             Vec::new(),
             10000,

--- a/src/backend/types.rs
+++ b/src/backend/types.rs
@@ -2,15 +2,8 @@
 pub use dash_spv::sync::{ManagerIdentifier, SyncProgress, SyncState};
 pub use dashcore::Network;
 pub use key_wallet::WalletCoreBalance;
-
-// UI-specific types that don't exist in rust-dashcore.
-
-/// Direction of a transaction relative to the wallet.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TransactionDirection {
-    Sent,
-    Received,
-}
+pub use key_wallet::managed_account::transaction_record::TransactionDirection;
+pub use key_wallet::transaction_checking::transaction_router::TransactionType;
 
 /// A UI-facing transaction record assembled from wallet events and sync state.
 ///
@@ -21,6 +14,7 @@ pub struct TransactionInfo {
     pub txid: dashcore::Txid,
     pub amount: i64,
     pub direction: TransactionDirection,
+    pub transaction_type: TransactionType,
     pub timestamp: u64,
     pub height: Option<u32>,
     pub fee: Option<u64>,
@@ -28,6 +22,7 @@ pub struct TransactionInfo {
     pub block_hash: Option<dashcore::BlockHash>,
     pub is_instant_send: bool,
     pub is_chain_locked: bool,
+    pub label: Option<String>,
 }
 
 impl TransactionInfo {

--- a/src/event_bridge.rs
+++ b/src/event_bridge.rs
@@ -47,9 +47,12 @@ pub fn use_event_bridge() {
 
 #[cfg(test)]
 mod tests {
+    use dashcore::hashes::Hash;
+
     use crate::backend::events::{SpvEvent, event_channel};
     use crate::backend::types::{
-        ManagerIdentifier, TransactionDirection, TransactionType, WalletCoreBalance,
+        ManagerIdentifier, TransactionDirection, TransactionInfo, TransactionType,
+        WalletCoreBalance,
     };
     use crate::state::connection::ConnectionState;
     use crate::state::dev_log::{DevLog, EventCategory};
@@ -109,19 +112,20 @@ mod tests {
     #[test]
     fn transaction_received_updates_wallet() {
         let (mut conn, mut wallet, mut net, mut log) = make_state();
-        let event = SpvEvent::TransactionReceived {
-            txid: [0xAA; 32],
+        let event = SpvEvent::TransactionReceived(Box::new(TransactionInfo {
+            txid: dashcore::Txid::from_byte_array([0xAA; 32]),
             amount: 500_000,
             direction: TransactionDirection::Incoming,
             transaction_type: TransactionType::Standard,
-            addresses: vec!["Xaddr1".into()],
+            timestamp: 1700000000,
             height: Some(1000),
-            timestamp: Some(1700000000),
+            fee: None,
+            addresses: vec!["Xaddr1".into()],
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: true,
             label: None,
-        };
+        }));
 
         dispatch_event(&event, &mut conn, &mut wallet, &mut net, &mut log);
 
@@ -364,19 +368,20 @@ mod tests {
                 best_height: 10000,
             },
             SpvEvent::SyncProgressUpdated(Box::default()),
-            SpvEvent::TransactionReceived {
-                txid: [1; 32],
+            SpvEvent::TransactionReceived(Box::new(TransactionInfo {
+                txid: dashcore::Txid::from_byte_array([1; 32]),
                 amount: 1_000_000,
                 direction: TransactionDirection::Incoming,
                 transaction_type: TransactionType::Standard,
-                addresses: vec!["Xaddr".into()],
+                timestamp: 1700000000,
                 height: Some(9999),
-                timestamp: Some(1700000000),
+                fee: None,
+                addresses: vec!["Xaddr".into()],
                 block_hash: None,
                 is_instant_send: true,
                 is_chain_locked: false,
                 label: None,
-            },
+            })),
             SpvEvent::BalanceUpdated(WalletCoreBalance::new(1_000_000, 0, 0, 0)),
             SpvEvent::SyncComplete {
                 tip_height: 10000,

--- a/src/event_bridge.rs
+++ b/src/event_bridge.rs
@@ -48,7 +48,9 @@ pub fn use_event_bridge() {
 #[cfg(test)]
 mod tests {
     use crate::backend::events::{SpvEvent, event_channel};
-    use crate::backend::types::{ManagerIdentifier, WalletCoreBalance};
+    use crate::backend::types::{
+        ManagerIdentifier, TransactionDirection, TransactionType, WalletCoreBalance,
+    };
     use crate::state::connection::ConnectionState;
     use crate::state::dev_log::{DevLog, EventCategory};
     use crate::state::network::NetworkInfo;
@@ -110,12 +112,15 @@ mod tests {
         let event = SpvEvent::TransactionReceived {
             txid: [0xAA; 32],
             amount: 500_000,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
             addresses: vec!["Xaddr1".into()],
             height: Some(1000),
             timestamp: Some(1700000000),
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: true,
+            label: None,
         };
 
         dispatch_event(&event, &mut conn, &mut wallet, &mut net, &mut log);
@@ -362,12 +367,15 @@ mod tests {
             SpvEvent::TransactionReceived {
                 txid: [1; 32],
                 amount: 1_000_000,
+                direction: TransactionDirection::Incoming,
+                transaction_type: TransactionType::Standard,
                 addresses: vec!["Xaddr".into()],
                 height: Some(9999),
                 timestamp: Some(1700000000),
                 block_hash: None,
                 is_instant_send: true,
                 is_chain_locked: false,
+                label: None,
             },
             SpvEvent::BalanceUpdated(WalletCoreBalance::new(1_000_000, 0, 0, 0)),
             SpvEvent::SyncComplete {

--- a/src/screens/dashboard.rs
+++ b/src/screens/dashboard.rs
@@ -72,9 +72,12 @@ pub fn Dashboard() -> Element {
                         for (i , tx) in transactions.iter().take(DASHBOARD_TX_LIMIT).enumerate() {
                             {
                                 let view = format_transaction(tx, current_height, unit);
-                                let is_sent = tx.direction == TransactionDirection::Outgoing;
                                 let bg = if i % 2 == 0 { "bg-card" } else { "bg-surface-alt" };
-                                let border = if is_sent { "border-error" } else { "border-success" };
+                                let border = match tx.direction {
+                                    TransactionDirection::Outgoing => "border-error",
+                                    TransactionDirection::Incoming => "border-success",
+                                    TransactionDirection::Internal | TransactionDirection::CoinJoin => "border-muted",
+                                };
                                 let is_expanded = *expanded_txid.read() == Some(tx.txid);
                                 let txid = tx.txid;
                                 let address_short = format_address_responsive(
@@ -99,14 +102,17 @@ pub fn Dashboard() -> Element {
                                                 }
                                             },
 
-
-
                                             div { class: "flex items-center gap-3 min-w-0 flex-1",
-                                                span { class: if is_sent { "text-error text-lg shrink-0" } else { "text-success text-lg shrink-0" },
-                                                    if is_sent {
-                                                        "▲"
-                                                    } else {
-                                                        "▼"
+                                                span {
+                                                    class: match tx.direction {
+                                                        TransactionDirection::Outgoing => "text-error text-lg shrink-0",
+                                                        TransactionDirection::Incoming => "text-success text-lg shrink-0",
+                                                        TransactionDirection::Internal | TransactionDirection::CoinJoin => "text-muted text-lg shrink-0",
+                                                    },
+                                                    match tx.direction {
+                                                        TransactionDirection::Outgoing => "▲",
+                                                        TransactionDirection::Incoming => "▼",
+                                                        TransactionDirection::Internal | TransactionDirection::CoinJoin => "⇄",
                                                     }
                                                 }
                                                 div { class: "min-w-0",
@@ -117,7 +123,12 @@ pub fn Dashboard() -> Element {
 
                                             div { class: "text-right flex items-center gap-2",
                                                 div {
-                                                    p { class: if is_sent { "text-error font-medium" } else { "text-success font-medium" },
+                                                    p {
+                                                        class: match tx.direction {
+                                                            TransactionDirection::Outgoing => "text-error font-medium",
+                                                            TransactionDirection::Incoming => "text-success font-medium",
+                                                            TransactionDirection::Internal | TransactionDirection::CoinJoin => "text-muted font-medium",
+                                                        },
                                                         "{view.amount_display}"
                                                     }
                                                     p { class: "text-disabled text-xs", "{view.confirmations_display}" }

--- a/src/screens/dashboard.rs
+++ b/src/screens/dashboard.rs
@@ -72,7 +72,7 @@ pub fn Dashboard() -> Element {
                         for (i , tx) in transactions.iter().take(DASHBOARD_TX_LIMIT).enumerate() {
                             {
                                 let view = format_transaction(tx, current_height, unit);
-                                let is_sent = tx.direction == TransactionDirection::Sent;
+                                let is_sent = tx.direction == TransactionDirection::Outgoing;
                                 let bg = if i % 2 == 0 { "bg-card" } else { "bg-surface-alt" };
                                 let border = if is_sent { "border-error" } else { "border-success" };
                                 let is_expanded = *expanded_txid.read() == Some(tx.txid);

--- a/src/screens/dashboard.rs
+++ b/src/screens/dashboard.rs
@@ -76,16 +76,13 @@ pub fn Dashboard() -> Element {
                                 let border = match tx.direction {
                                     TransactionDirection::Outgoing => "border-error",
                                     TransactionDirection::Incoming => "border-success",
-                                    TransactionDirection::Internal | TransactionDirection::CoinJoin => "border-muted",
+                                    TransactionDirection::Internal | TransactionDirection::CoinJoin => {
+                                        "border-muted"
+                                    }
                                 };
                                 let is_expanded = *expanded_txid.read() == Some(tx.txid);
                                 let txid = tx.txid;
                                 let address_short = format_address_responsive(
-
-                                    // Left: direction + address + time
-
-                                    // Right: amount + confirmations + badges
-
                                     &tx.addresses.first().cloned().unwrap_or_default(),
                                     20,
                                 );
@@ -102,12 +99,16 @@ pub fn Dashboard() -> Element {
                                                 }
                                             },
 
+
+
                                             div { class: "flex items-center gap-3 min-w-0 flex-1",
                                                 span {
                                                     class: match tx.direction {
                                                         TransactionDirection::Outgoing => "text-error text-lg shrink-0",
                                                         TransactionDirection::Incoming => "text-success text-lg shrink-0",
-                                                        TransactionDirection::Internal | TransactionDirection::CoinJoin => "text-muted text-lg shrink-0",
+                                                        TransactionDirection::Internal | TransactionDirection::CoinJoin => {
+                                                            "text-muted text-lg shrink-0"
+                                                        }
                                                     },
                                                     match tx.direction {
                                                         TransactionDirection::Outgoing => "▲",
@@ -127,7 +128,9 @@ pub fn Dashboard() -> Element {
                                                         class: match tx.direction {
                                                             TransactionDirection::Outgoing => "text-error font-medium",
                                                             TransactionDirection::Incoming => "text-success font-medium",
-                                                            TransactionDirection::Internal | TransactionDirection::CoinJoin => "text-muted font-medium",
+                                                            TransactionDirection::Internal | TransactionDirection::CoinJoin => {
+                                                                "text-muted font-medium"
+                                                            }
                                                         },
                                                         "{view.amount_display}"
                                                     }

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -148,7 +148,10 @@ pub fn Transactions() -> Element {
                             let border = match tx.direction {
                                 TransactionDirection::Outgoing => "border-error",
                                 TransactionDirection::Incoming => "border-success",
-                                TransactionDirection::Internal | TransactionDirection::CoinJoin => "border-muted",
+
+                                TransactionDirection::Internal | TransactionDirection::CoinJoin => {
+                                    "border-muted"
+                                }
                             };
                             let address_short = format_address_responsive(
                                 &tx.addresses.first().cloned().unwrap_or_default(),
@@ -170,12 +173,16 @@ pub fn Transactions() -> Element {
                                             }
                                         },
 
+
+
                                         div { class: "flex items-center gap-3 min-w-0",
                                             span {
                                                 class: match tx.direction {
                                                     TransactionDirection::Outgoing => "text-error text-lg flex-shrink-0",
                                                     TransactionDirection::Incoming => "text-success text-lg flex-shrink-0",
-                                                    TransactionDirection::Internal | TransactionDirection::CoinJoin => "text-muted text-lg flex-shrink-0",
+                                                    TransactionDirection::Internal | TransactionDirection::CoinJoin => {
+                                                        "text-muted text-lg flex-shrink-0"
+                                                    }
                                                 },
                                                 match tx.direction {
                                                     TransactionDirection::Outgoing => "▲",
@@ -195,7 +202,9 @@ pub fn Transactions() -> Element {
                                                     class: match tx.direction {
                                                         TransactionDirection::Outgoing => "text-error font-medium",
                                                         TransactionDirection::Incoming => "text-success font-medium",
-                                                        TransactionDirection::Internal | TransactionDirection::CoinJoin => "text-muted font-medium",
+                                                        TransactionDirection::Internal | TransactionDirection::CoinJoin => {
+                                                            "text-muted font-medium"
+                                                        }
                                                     },
                                                     "{view.amount_display}"
                                                 }

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -14,16 +14,20 @@ const PAGE_SIZE: usize = 50;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TxFilter {
     All,
-    Received,
-    Sent,
+    Incoming,
+    Outgoing,
+    Internal,
+    CoinJoin,
 }
 
 impl TxFilter {
     fn label(self) -> &'static str {
         match self {
             Self::All => "All",
-            Self::Received => "Received",
-            Self::Sent => "Sent",
+            Self::Incoming => "Received",
+            Self::Outgoing => "Sent",
+            Self::Internal => "Internal",
+            Self::CoinJoin => "CoinJoin",
         }
     }
 }
@@ -37,8 +41,10 @@ fn apply_filters<'a>(
     txs.iter()
         .filter(|tx| match filter {
             TxFilter::All => true,
-            TxFilter::Received => tx.direction == TransactionDirection::Received,
-            TxFilter::Sent => tx.direction == TransactionDirection::Sent,
+            TxFilter::Incoming => tx.direction == TransactionDirection::Incoming,
+            TxFilter::Outgoing => tx.direction == TransactionDirection::Outgoing,
+            TxFilter::Internal => tx.direction == TransactionDirection::Internal,
+            TxFilter::CoinJoin => tx.direction == TransactionDirection::CoinJoin,
         })
         .filter(|tx| matches_search(tx, search, unit))
         .collect()
@@ -104,7 +110,7 @@ pub fn Transactions() -> Element {
 
             // Filter tabs
             div { class: "flex gap-2 mb-6",
-                for filter in [TxFilter::All, TxFilter::Received, TxFilter::Sent] {
+                for filter in [TxFilter::All, TxFilter::Incoming, TxFilter::Outgoing, TxFilter::Internal, TxFilter::CoinJoin] {
                     {
                         let is_active = *active_filter.read() == filter;
                         let class = if is_active {
@@ -142,7 +148,7 @@ pub fn Transactions() -> Element {
                     for (i , tx) in filtered.iter().take(visible).enumerate() {
                         {
                             let view = format_transaction(tx, current_height, unit);
-                            let is_sent = tx.direction == TransactionDirection::Sent;
+                            let is_sent = tx.direction == TransactionDirection::Outgoing;
                             let bg = if i % 2 == 0 { "bg-card" } else { "bg-surface-alt" };
                             let border = if is_sent { "border-error" } else { "border-success" };
                             let address_short = format_address_responsive(
@@ -288,6 +294,8 @@ pub fn Transactions() -> Element {
 mod tests {
     use dashcore::hashes::Hash;
 
+    use crate::backend::types::TransactionType;
+
     use super::*;
 
     fn sample_txs() -> Vec<TransactionInfo> {
@@ -295,7 +303,8 @@ mod tests {
             TransactionInfo {
                 txid: dashcore::Txid::from_byte_array([0xAA; 32]),
                 amount: 100_000_000,
-                direction: TransactionDirection::Received,
+                direction: TransactionDirection::Incoming,
+                transaction_type: TransactionType::Standard,
                 timestamp: 1700000000,
                 height: Some(100),
                 fee: None,
@@ -303,11 +312,13 @@ mod tests {
                 block_hash: None,
                 is_instant_send: false,
                 is_chain_locked: false,
+                label: None,
             },
             TransactionInfo {
                 txid: dashcore::Txid::from_byte_array([0xBB; 32]),
                 amount: -50_000_000,
-                direction: TransactionDirection::Sent,
+                direction: TransactionDirection::Outgoing,
+                transaction_type: TransactionType::Standard,
                 timestamp: 1700001000,
                 height: Some(101),
                 fee: Some(226),
@@ -315,11 +326,13 @@ mod tests {
                 block_hash: None,
                 is_instant_send: false,
                 is_chain_locked: false,
+                label: None,
             },
             TransactionInfo {
                 txid: dashcore::Txid::from_byte_array([0xCC; 32]),
                 amount: 200_000_000,
-                direction: TransactionDirection::Received,
+                direction: TransactionDirection::Incoming,
+                transaction_type: TransactionType::Standard,
                 timestamp: 1700002000,
                 height: Some(102),
                 fee: None,
@@ -327,6 +340,7 @@ mod tests {
                 block_hash: None,
                 is_instant_send: true,
                 is_chain_locked: false,
+                label: None,
             },
         ]
     }
@@ -341,21 +355,21 @@ mod tests {
     #[test]
     fn apply_filters_received_only() {
         let txs = sample_txs();
-        let result = apply_filters(&txs, TxFilter::Received, "", "DASH");
+        let result = apply_filters(&txs, TxFilter::Incoming, "", "DASH");
         assert_eq!(result.len(), 2);
         assert!(
             result
                 .iter()
-                .all(|tx| tx.direction == TransactionDirection::Received)
+                .all(|tx| tx.direction == TransactionDirection::Incoming)
         );
     }
 
     #[test]
     fn apply_filters_sent_only() {
         let txs = sample_txs();
-        let result = apply_filters(&txs, TxFilter::Sent, "", "DASH");
+        let result = apply_filters(&txs, TxFilter::Outgoing, "", "DASH");
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].direction, TransactionDirection::Sent);
+        assert_eq!(result[0].direction, TransactionDirection::Outgoing);
     }
 
     #[test]
@@ -376,7 +390,7 @@ mod tests {
     #[test]
     fn apply_filters_combined_filter_and_search() {
         let txs = sample_txs();
-        let result = apply_filters(&txs, TxFilter::Received, "yAddr3", "DASH");
+        let result = apply_filters(&txs, TxFilter::Incoming, "yAddr3", "DASH");
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].addresses[0], "yAddr3");
     }
@@ -391,7 +405,9 @@ mod tests {
     #[test]
     fn tx_filter_labels() {
         assert_eq!(TxFilter::All.label(), "All");
-        assert_eq!(TxFilter::Received.label(), "Received");
-        assert_eq!(TxFilter::Sent.label(), "Sent");
+        assert_eq!(TxFilter::Incoming.label(), "Received");
+        assert_eq!(TxFilter::Outgoing.label(), "Sent");
+        assert_eq!(TxFilter::Internal.label(), "Internal");
+        assert_eq!(TxFilter::CoinJoin.label(), "CoinJoin");
     }
 }

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -11,40 +11,35 @@ use crate::state::wallet::WalletState;
 
 const PAGE_SIZE: usize = 50;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TxFilter {
-    All,
-    Incoming,
-    Outgoing,
-    Internal,
-    CoinJoin,
-}
+/// Filter tabs: `None` means "All", `Some(dir)` filters to that direction.
+const FILTER_TABS: [Option<TransactionDirection>; 5] = [
+    None,
+    Some(TransactionDirection::Incoming),
+    Some(TransactionDirection::Outgoing),
+    Some(TransactionDirection::Internal),
+    Some(TransactionDirection::CoinJoin),
+];
 
-impl TxFilter {
-    fn label(self) -> &'static str {
-        match self {
-            Self::All => "All",
-            Self::Incoming => "Received",
-            Self::Outgoing => "Sent",
-            Self::Internal => "Internal",
-            Self::CoinJoin => "CoinJoin",
-        }
+fn filter_label(filter: Option<TransactionDirection>) -> &'static str {
+    match filter {
+        None => "All",
+        Some(TransactionDirection::Incoming) => "Received",
+        Some(TransactionDirection::Outgoing) => "Sent",
+        Some(TransactionDirection::Internal) => "Internal",
+        Some(TransactionDirection::CoinJoin) => "CoinJoin",
     }
 }
 
 fn apply_filters<'a>(
     txs: &'a [TransactionInfo],
-    filter: TxFilter,
+    filter: Option<TransactionDirection>,
     search: &str,
     unit: &str,
 ) -> Vec<&'a TransactionInfo> {
     txs.iter()
         .filter(|tx| match filter {
-            TxFilter::All => true,
-            TxFilter::Incoming => tx.direction == TransactionDirection::Incoming,
-            TxFilter::Outgoing => tx.direction == TransactionDirection::Outgoing,
-            TxFilter::Internal => tx.direction == TransactionDirection::Internal,
-            TxFilter::CoinJoin => tx.direction == TransactionDirection::CoinJoin,
+            None => true,
+            Some(dir) => tx.direction == dir,
         })
         .filter(|tx| matches_search(tx, search, unit))
         .collect()
@@ -57,7 +52,7 @@ pub fn Transactions() -> Element {
     let config = use_context::<Signal<AppConfig>>();
 
     let mut search_query = use_signal(String::new);
-    let mut active_filter = use_signal(|| TxFilter::All);
+    let mut active_filter = use_signal(|| None::<TransactionDirection>);
     let mut visible_count = use_signal(|| PAGE_SIZE);
     let mut expanded_txid = use_signal(|| None::<dashcore::Txid>);
 
@@ -110,7 +105,7 @@ pub fn Transactions() -> Element {
 
             // Filter tabs
             div { class: "flex gap-2 mb-6",
-                for filter in [TxFilter::All, TxFilter::Incoming, TxFilter::Outgoing, TxFilter::Internal, TxFilter::CoinJoin] {
+                for filter in FILTER_TABS {
                     {
                         let is_active = *active_filter.read() == filter;
                         let class = if is_active {
@@ -118,6 +113,7 @@ pub fn Transactions() -> Element {
                         } else {
                             "px-4 py-2 rounded-lg bg-card text-muted hover:bg-hover transition-colors"
                         };
+                        let label = filter_label(filter);
                         rsx! {
                             button {
                                 class,
@@ -125,7 +121,7 @@ pub fn Transactions() -> Element {
                                     active_filter.set(filter);
                                     visible_count.set(PAGE_SIZE);
                                 },
-                                "{filter.label()}"
+                                "{label}"
                             }
                         }
                     }
@@ -348,14 +344,14 @@ mod tests {
     #[test]
     fn apply_filters_all() {
         let txs = sample_txs();
-        let result = apply_filters(&txs, TxFilter::All, "", "DASH");
+        let result = apply_filters(&txs, None, "", "DASH");
         assert_eq!(result.len(), 3);
     }
 
     #[test]
     fn apply_filters_received_only() {
         let txs = sample_txs();
-        let result = apply_filters(&txs, TxFilter::Incoming, "", "DASH");
+        let result = apply_filters(&txs, Some(TransactionDirection::Incoming), "", "DASH");
         assert_eq!(result.len(), 2);
         assert!(
             result
@@ -367,7 +363,7 @@ mod tests {
     #[test]
     fn apply_filters_sent_only() {
         let txs = sample_txs();
-        let result = apply_filters(&txs, TxFilter::Outgoing, "", "DASH");
+        let result = apply_filters(&txs, Some(TransactionDirection::Outgoing), "", "DASH");
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].direction, TransactionDirection::Outgoing);
     }
@@ -375,7 +371,7 @@ mod tests {
     #[test]
     fn apply_filters_with_search() {
         let txs = sample_txs();
-        let result = apply_filters(&txs, TxFilter::All, "yAddr2", "DASH");
+        let result = apply_filters(&txs, None, "yAddr2", "DASH");
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].addresses[0], "yAddr2");
     }
@@ -383,14 +379,14 @@ mod tests {
     #[test]
     fn apply_filters_no_match() {
         let txs = sample_txs();
-        let result = apply_filters(&txs, TxFilter::All, "zzz_nonexistent", "DASH");
+        let result = apply_filters(&txs, None, "zzz_nonexistent", "DASH");
         assert!(result.is_empty());
     }
 
     #[test]
     fn apply_filters_combined_filter_and_search() {
         let txs = sample_txs();
-        let result = apply_filters(&txs, TxFilter::Incoming, "yAddr3", "DASH");
+        let result = apply_filters(&txs, Some(TransactionDirection::Incoming), "yAddr3", "DASH");
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].addresses[0], "yAddr3");
     }
@@ -398,16 +394,25 @@ mod tests {
     #[test]
     fn apply_filters_empty_transactions() {
         let txs: Vec<TransactionInfo> = vec![];
-        let result = apply_filters(&txs, TxFilter::All, "", "DASH");
+        let result = apply_filters(&txs, None, "", "DASH");
         assert!(result.is_empty());
     }
 
     #[test]
-    fn tx_filter_labels() {
-        assert_eq!(TxFilter::All.label(), "All");
-        assert_eq!(TxFilter::Incoming.label(), "Received");
-        assert_eq!(TxFilter::Outgoing.label(), "Sent");
-        assert_eq!(TxFilter::Internal.label(), "Internal");
-        assert_eq!(TxFilter::CoinJoin.label(), "CoinJoin");
+    fn filter_labels() {
+        assert_eq!(filter_label(None), "All");
+        assert_eq!(
+            filter_label(Some(TransactionDirection::Incoming)),
+            "Received"
+        );
+        assert_eq!(filter_label(Some(TransactionDirection::Outgoing)), "Sent");
+        assert_eq!(
+            filter_label(Some(TransactionDirection::Internal)),
+            "Internal"
+        );
+        assert_eq!(
+            filter_label(Some(TransactionDirection::CoinJoin)),
+            "CoinJoin"
+        );
     }
 }

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -144,15 +144,13 @@ pub fn Transactions() -> Element {
                     for (i , tx) in filtered.iter().take(visible).enumerate() {
                         {
                             let view = format_transaction(tx, current_height, unit);
-                            let is_sent = tx.direction == TransactionDirection::Outgoing;
                             let bg = if i % 2 == 0 { "bg-card" } else { "bg-surface-alt" };
-                            let border = if is_sent { "border-error" } else { "border-success" };
+                            let border = match tx.direction {
+                                TransactionDirection::Outgoing => "border-error",
+                                TransactionDirection::Incoming => "border-success",
+                                TransactionDirection::Internal | TransactionDirection::CoinJoin => "border-muted",
+                            };
                             let address_short = format_address_responsive(
-
-                                // Left: direction + address + time
-
-                                // Right: amount + confirmations + height + badges
-
                                 &tx.addresses.first().cloned().unwrap_or_default(),
                                 30,
                             );
@@ -172,14 +170,17 @@ pub fn Transactions() -> Element {
                                             }
                                         },
 
-
-
                                         div { class: "flex items-center gap-3 min-w-0",
-                                            span { class: if is_sent { "text-error text-lg flex-shrink-0" } else { "text-success text-lg flex-shrink-0" },
-                                                if is_sent {
-                                                    "▲"
-                                                } else {
-                                                    "▼"
+                                            span {
+                                                class: match tx.direction {
+                                                    TransactionDirection::Outgoing => "text-error text-lg flex-shrink-0",
+                                                    TransactionDirection::Incoming => "text-success text-lg flex-shrink-0",
+                                                    TransactionDirection::Internal | TransactionDirection::CoinJoin => "text-muted text-lg flex-shrink-0",
+                                                },
+                                                match tx.direction {
+                                                    TransactionDirection::Outgoing => "▲",
+                                                    TransactionDirection::Incoming => "▼",
+                                                    TransactionDirection::Internal | TransactionDirection::CoinJoin => "⇄",
                                                 }
                                             }
                                             div { class: "min-w-0",
@@ -190,7 +191,12 @@ pub fn Transactions() -> Element {
 
                                         div { class: "text-right flex items-center gap-2 flex-shrink-0",
                                             div {
-                                                p { class: if is_sent { "text-error font-medium" } else { "text-success font-medium" },
+                                                p {
+                                                    class: match tx.direction {
+                                                        TransactionDirection::Outgoing => "text-error font-medium",
+                                                        TransactionDirection::Incoming => "text-success font-medium",
+                                                        TransactionDirection::Internal | TransactionDirection::CoinJoin => "text-muted font-medium",
+                                                    },
                                                     "{view.amount_display}"
                                                 }
                                                 p { class: "text-disabled text-xs",

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -399,6 +399,52 @@ mod tests {
     }
 
     #[test]
+    fn apply_filters_internal_only() {
+        let mut txs = sample_txs();
+        txs.push(TransactionInfo {
+            txid: dashcore::Txid::from_byte_array([0xDD; 32]),
+            amount: 10_000,
+            direction: TransactionDirection::Internal,
+            transaction_type: TransactionType::Standard,
+            timestamp: 1700003000,
+            height: Some(103),
+            fee: None,
+            addresses: vec!["yAddr4".into()],
+            block_hash: None,
+            is_instant_send: false,
+            is_chain_locked: false,
+            label: None,
+        });
+
+        let result = apply_filters(&txs, Some(TransactionDirection::Internal), "", "DASH");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].direction, TransactionDirection::Internal);
+    }
+
+    #[test]
+    fn apply_filters_coinjoin_only() {
+        let mut txs = sample_txs();
+        txs.push(TransactionInfo {
+            txid: dashcore::Txid::from_byte_array([0xEE; 32]),
+            amount: -25_000_000,
+            direction: TransactionDirection::CoinJoin,
+            transaction_type: TransactionType::CoinJoin,
+            timestamp: 1700004000,
+            height: Some(104),
+            fee: Some(100),
+            addresses: vec!["yAddr5".into()],
+            block_hash: None,
+            is_instant_send: false,
+            is_chain_locked: false,
+            label: None,
+        });
+
+        let result = apply_filters(&txs, Some(TransactionDirection::CoinJoin), "", "DASH");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].direction, TransactionDirection::CoinJoin);
+    }
+
+    #[test]
     fn filter_labels() {
         assert_eq!(filter_label(None), "All");
         assert_eq!(

--- a/src/state/dev_log.rs
+++ b/src/state/dev_log.rs
@@ -114,17 +114,16 @@ fn categorize_event(event: &SpvEvent) -> (EventCategory, String) {
             EventCategory::Network,
             format!("Peers: {count}, best height: {best_height}"),
         ),
-        SpvEvent::TransactionReceived {
-            txid,
-            amount,
-            addresses,
-            ..
-        } => {
-            let txid_short = hex::encode(&txid[..4]);
-            let addr = addresses.first().map(|a| a.as_str()).unwrap_or("unknown");
+        SpvEvent::TransactionReceived(info) => {
+            let txid_short = &info.txid.to_string()[..8];
+            let addr = info
+                .addresses
+                .first()
+                .map(|a| a.as_str())
+                .unwrap_or("unknown");
             (
                 EventCategory::Wallet,
-                format!("Transaction {txid_short}...: {amount} sat ({addr})"),
+                format!("Transaction {txid_short}...: {} sat ({addr})", info.amount),
             )
         }
         SpvEvent::BalanceUpdated(b) => (
@@ -162,8 +161,12 @@ fn sync_state_label(state: SyncState) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use dashcore::hashes::Hash;
+
     use super::*;
-    use crate::backend::types::{TransactionDirection, TransactionType, WalletCoreBalance};
+    use crate::backend::types::{
+        TransactionDirection, TransactionInfo, TransactionType, WalletCoreBalance,
+    };
 
     #[test]
     fn push_and_retrieve() {
@@ -267,19 +270,20 @@ mod tests {
                 EventCategory::Wallet,
             ),
             (
-                SpvEvent::TransactionReceived {
-                    txid: [0; 32],
+                SpvEvent::TransactionReceived(Box::new(TransactionInfo {
+                    txid: dashcore::Txid::from_byte_array([0; 32]),
                     amount: 0,
                     direction: TransactionDirection::Incoming,
                     transaction_type: TransactionType::Standard,
-                    addresses: vec![],
+                    timestamp: 0,
                     height: None,
-                    timestamp: None,
+                    fee: None,
+                    addresses: vec![],
                     block_hash: None,
                     is_instant_send: false,
                     is_chain_locked: false,
                     label: None,
-                },
+                })),
                 EventCategory::Wallet,
             ),
             (SpvEvent::Error("e".into()), EventCategory::Error),

--- a/src/state/dev_log.rs
+++ b/src/state/dev_log.rs
@@ -163,7 +163,7 @@ fn sync_state_label(state: SyncState) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::types::WalletCoreBalance;
+    use crate::backend::types::{TransactionDirection, TransactionType, WalletCoreBalance};
 
     #[test]
     fn push_and_retrieve() {
@@ -270,12 +270,15 @@ mod tests {
                 SpvEvent::TransactionReceived {
                     txid: [0; 32],
                     amount: 0,
+                    direction: TransactionDirection::Incoming,
+                    transaction_type: TransactionType::Standard,
                     addresses: vec![],
                     height: None,
                     timestamp: None,
                     block_hash: None,
                     is_instant_send: false,
                     is_chain_locked: false,
+                    label: None,
                 },
                 EventCategory::Wallet,
             ),

--- a/src/state/view_models.rs
+++ b/src/state/view_models.rs
@@ -231,8 +231,10 @@ pub fn format_transaction(
 ) -> TransactionView {
     let txid_hex = tx.txid.to_string();
     let direction_label = match tx.direction {
-        TransactionDirection::Sent => "Sent",
-        TransactionDirection::Received => "Received",
+        TransactionDirection::Outgoing => "Sent",
+        TransactionDirection::Incoming => "Received",
+        TransactionDirection::Internal => "Internal",
+        TransactionDirection::CoinJoin => "CoinJoin",
     };
     let amount_display = format_amount(tx.amount, unit);
     let timestamp_display = format_timestamp(tx.timestamp);
@@ -263,6 +265,8 @@ pub fn format_transaction(
 #[cfg(test)]
 mod tests {
     use dashcore::hashes::Hash;
+
+    use crate::backend::types::TransactionType;
 
     use super::*;
 
@@ -441,7 +445,8 @@ mod tests {
         let tx = TransactionInfo {
             txid: dashcore::Txid::from_byte_array([0xAB; 32]),
             amount: 100_000_000,
-            direction: TransactionDirection::Received,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
             timestamp: 1700000000,
             height: Some(994),
             fee: None,
@@ -449,6 +454,7 @@ mod tests {
             block_hash: None,
             is_instant_send: true,
             is_chain_locked: false,
+            label: None,
         };
 
         let view = format_transaction(&tx, 1000, "DASH");
@@ -466,7 +472,8 @@ mod tests {
         let tx = TransactionInfo {
             txid: dashcore::Txid::from_byte_array([0xCD; 32]),
             amount: -50_000_000,
-            direction: TransactionDirection::Sent,
+            direction: TransactionDirection::Outgoing,
+            transaction_type: TransactionType::Standard,
             timestamp: 1700000000,
             height: None,
             fee: Some(226),
@@ -474,6 +481,7 @@ mod tests {
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: false,
+            label: None,
         };
 
         let view = format_transaction(&tx, 1000, "DASH");
@@ -487,7 +495,8 @@ mod tests {
         let tx = TransactionInfo {
             txid: dashcore::Txid::from_byte_array([0xAB; 32]),
             amount: 100_000_000,
-            direction: TransactionDirection::Received,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
             timestamp: 1700000000,
             height: Some(994),
             fee: None,
@@ -495,6 +504,7 @@ mod tests {
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: false,
+            label: None,
         };
 
         let view = format_transaction(&tx, 1000, "tDASH");
@@ -506,7 +516,8 @@ mod tests {
         let tx = TransactionInfo {
             txid: dashcore::Txid::from_byte_array([0; 32]),
             amount: 0,
-            direction: TransactionDirection::Received,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
             timestamp: 0,
             height: None,
             fee: None,
@@ -514,6 +525,7 @@ mod tests {
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: false,
+            label: None,
         };
 
         let view = format_transaction(&tx, 0, "DASH");
@@ -568,7 +580,8 @@ mod tests {
         TransactionInfo {
             txid: dashcore::Txid::from_byte_array([0xAB; 32]),
             amount: 150_000_000,
-            direction: TransactionDirection::Received,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
             timestamp: 1700000000,
             height: Some(1000),
             fee: None,
@@ -576,6 +589,7 @@ mod tests {
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: false,
+            label: None,
         }
     }
 

--- a/src/state/view_models.rs
+++ b/src/state/view_models.rs
@@ -208,6 +208,10 @@ pub fn matches_search(tx: &TransactionInfo, query: &str, unit: &str) -> bool {
         || format_balance(tx.amount.unsigned_abs(), unit)
             .to_lowercase()
             .contains(&q)
+        || tx
+            .label
+            .as_ref()
+            .is_some_and(|l| l.to_lowercase().contains(&q))
 }
 
 /// Display-ready transaction info.
@@ -618,6 +622,14 @@ mod tests {
     #[test]
     fn matches_search_no_match() {
         assert!(!matches_search(&sample_tx(), "zzz_no_match_zzz", "DASH"));
+    }
+
+    #[test]
+    fn matches_search_by_label() {
+        let mut tx = sample_tx();
+        tx.label = Some("coffee payment".into());
+        assert!(matches_search(&tx, "coffee", "DASH"));
+        assert!(!matches_search(&tx, "groceries", "DASH"));
     }
 
     #[test]

--- a/src/state/wallet.rs
+++ b/src/state/wallet.rs
@@ -37,7 +37,9 @@ impl WalletState {
                 // the incoming event is a status-only update (amount == 0).
                 if let Some(existing) = self.transactions.iter_mut().find(|t| t.txid == info.txid) {
                     existing.height = info.height;
-                    existing.timestamp = info.timestamp;
+                    if info.timestamp > 0 {
+                        existing.timestamp = info.timestamp;
+                    }
                     existing.block_hash = info.block_hash;
                     existing.is_instant_send = info.is_instant_send;
                     existing.is_chain_locked = info.is_chain_locked;
@@ -290,6 +292,28 @@ mod tests {
         assert_eq!(tx.amount, -75_000);
         assert_eq!(tx.height, Some(3000));
         assert!(tx.is_chain_locked);
+    }
+
+    #[test]
+    fn status_update_does_not_overwrite_timestamp_with_zero() {
+        let mut state = WalletState::default();
+
+        state.apply_event(&tx_event(
+            8,
+            100_000,
+            TransactionDirection::Incoming,
+            vec!["Xaddr8".into()],
+            None,
+            1700000000,
+        ));
+        assert_eq!(state.transactions[0].timestamp, 1700000000);
+
+        // Status update with timestamp 0 should not overwrite
+        state.apply_event(&status_event(8, Some(500), 0, false, true));
+
+        assert_eq!(state.transactions[0].timestamp, 1700000000);
+        assert_eq!(state.transactions[0].height, Some(500));
+        assert!(state.transactions[0].is_chain_locked);
     }
 
     #[test]

--- a/src/state/wallet.rs
+++ b/src/state/wallet.rs
@@ -1,7 +1,5 @@
 use std::cmp::Ordering;
 
-use dashcore::hashes::Hash;
-
 use crate::backend::events::SpvEvent;
 use crate::backend::types::{TransactionInfo, WalletCoreBalance};
 
@@ -33,66 +31,28 @@ impl WalletState {
             SpvEvent::BalanceUpdated(balance) => {
                 self.balance = *balance;
             }
-            SpvEvent::TransactionReceived {
-                txid,
-                amount,
-                direction,
-                transaction_type,
-                addresses,
-                height,
-                timestamp,
-                block_hash,
-                is_instant_send,
-                is_chain_locked,
-                label,
-            } => {
-                let txid_parsed = dashcore::Txid::from_byte_array(*txid);
-
-                // If this txid already exists, update its status fields
-                if let Some(existing) = self.transactions.iter_mut().find(|t| t.txid == txid_parsed)
-                {
-                    existing.height = *height;
-                    if let Some(ts) = timestamp {
-                        existing.timestamp = *ts;
-                    }
-                    if let Some(bh) = block_hash {
-                        existing.block_hash = Some(dashcore::BlockHash::from_byte_array(*bh));
-                    }
-                    existing.is_instant_send = *is_instant_send;
-                    existing.is_chain_locked = *is_chain_locked;
-                    // Update amount/addresses/direction if this is a full event (not a status-only update)
-                    if *amount != 0 {
-                        existing.amount = *amount;
-                        existing.direction = *direction;
-                        existing.transaction_type = *transaction_type;
-                        existing.addresses.clone_from(addresses);
-                        existing.label.clone_from(label);
+            SpvEvent::TransactionReceived(info) => {
+                // If this txid already exists, update its context fields and
+                // preserve direction/type/label from the original record when
+                // the incoming event is a status-only update (amount == 0).
+                if let Some(existing) = self.transactions.iter_mut().find(|t| t.txid == info.txid) {
+                    existing.height = info.height;
+                    existing.timestamp = info.timestamp;
+                    existing.block_hash = info.block_hash;
+                    existing.is_instant_send = info.is_instant_send;
+                    existing.is_chain_locked = info.is_chain_locked;
+                    if info.amount != 0 {
+                        existing.amount = info.amount;
+                        existing.direction = info.direction;
+                        existing.transaction_type = info.transaction_type;
+                        existing.addresses.clone_from(&info.addresses);
+                        existing.label.clone_from(&info.label);
                     }
                     sort_transactions(&mut self.transactions);
                     return;
                 }
 
-                let fallback_timestamp = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs();
-
-                let record = TransactionInfo {
-                    txid: txid_parsed,
-                    amount: *amount,
-                    direction: *direction,
-                    transaction_type: *transaction_type,
-                    timestamp: timestamp.unwrap_or(fallback_timestamp),
-                    height: *height,
-                    fee: None,
-                    addresses: addresses.clone(),
-                    block_hash: block_hash.map(dashcore::BlockHash::from_byte_array),
-                    is_instant_send: *is_instant_send,
-                    is_chain_locked: *is_chain_locked,
-                    label: label.clone(),
-                };
-
-                self.transactions.push(record);
+                self.transactions.push(*info.clone());
                 sort_transactions(&mut self.transactions);
             }
             _ => {}
@@ -108,9 +68,58 @@ impl WalletState {
 
 #[cfg(test)]
 mod tests {
+    use dashcore::hashes::Hash;
+
     use crate::backend::types::{TransactionDirection, TransactionType};
 
     use super::*;
+
+    fn tx_event(
+        txid_byte: u8,
+        amount: i64,
+        direction: TransactionDirection,
+        addresses: Vec<String>,
+        height: Option<u32>,
+        timestamp: u64,
+    ) -> SpvEvent {
+        SpvEvent::TransactionReceived(Box::new(TransactionInfo {
+            txid: dashcore::Txid::from_byte_array([txid_byte; 32]),
+            amount,
+            direction,
+            transaction_type: TransactionType::Standard,
+            timestamp,
+            height,
+            fee: None,
+            addresses,
+            block_hash: None,
+            is_instant_send: false,
+            is_chain_locked: false,
+            label: None,
+        }))
+    }
+
+    fn status_event(
+        txid_byte: u8,
+        height: Option<u32>,
+        timestamp: u64,
+        is_instant_send: bool,
+        is_chain_locked: bool,
+    ) -> SpvEvent {
+        SpvEvent::TransactionReceived(Box::new(TransactionInfo {
+            txid: dashcore::Txid::from_byte_array([txid_byte; 32]),
+            amount: 0,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
+            timestamp,
+            height,
+            fee: None,
+            addresses: Vec::new(),
+            block_hash: None,
+            is_instant_send,
+            is_chain_locked,
+            label: None,
+        }))
+    }
 
     #[test]
     fn default_state() {
@@ -132,38 +141,28 @@ mod tests {
     fn transaction_received_events_sorted_by_timestamp() {
         let mut state = WalletState::default();
 
-        state.apply_event(&SpvEvent::TransactionReceived {
-            txid: [1u8; 32],
-            amount: 100_000,
-            direction: TransactionDirection::Incoming,
-            transaction_type: TransactionType::Standard,
-            addresses: vec!["Xaddr1".into()],
-            height: None,
-            timestamp: Some(1000),
-            block_hash: None,
-            is_instant_send: false,
-            is_chain_locked: false,
-            label: None,
-        });
+        state.apply_event(&tx_event(
+            1,
+            100_000,
+            TransactionDirection::Incoming,
+            vec!["Xaddr1".into()],
+            None,
+            1000,
+        ));
         assert_eq!(state.transactions.len(), 1);
         assert_eq!(
             state.transactions[0].direction,
             TransactionDirection::Incoming
         );
 
-        state.apply_event(&SpvEvent::TransactionReceived {
-            txid: [2u8; 32],
-            amount: -50_000,
-            direction: TransactionDirection::Outgoing,
-            transaction_type: TransactionType::Standard,
-            addresses: vec!["Xaddr2".into()],
-            height: None,
-            timestamp: Some(2000),
-            block_hash: None,
-            is_instant_send: false,
-            is_chain_locked: false,
-            label: None,
-        });
+        state.apply_event(&tx_event(
+            2,
+            -50_000,
+            TransactionDirection::Outgoing,
+            vec!["Xaddr2".into()],
+            None,
+            2000,
+        ));
         assert_eq!(state.transactions.len(), 2);
         // Newer unconfirmed tx sorts first
         assert_eq!(
@@ -180,19 +179,21 @@ mod tests {
     fn transaction_received_with_confirmation_data() {
         let mut state = WalletState::default();
 
-        state.apply_event(&SpvEvent::TransactionReceived {
-            txid: [3u8; 32],
+        let event = SpvEvent::TransactionReceived(Box::new(TransactionInfo {
+            txid: dashcore::Txid::from_byte_array([3u8; 32]),
             amount: 200_000,
             direction: TransactionDirection::Incoming,
             transaction_type: TransactionType::Standard,
-            addresses: vec!["Xaddr3".into()],
+            timestamp: 1700000000,
             height: Some(1000),
-            timestamp: Some(1700000000),
+            fee: None,
+            addresses: vec!["Xaddr3".into()],
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: true,
             label: None,
-        });
+        }));
+        state.apply_event(&event);
 
         assert_eq!(state.transactions.len(), 1);
         let tx = &state.transactions[0];
@@ -206,19 +207,20 @@ mod tests {
     fn transaction_received_instant_send() {
         let mut state = WalletState::default();
 
-        state.apply_event(&SpvEvent::TransactionReceived {
-            txid: [4u8; 32],
+        state.apply_event(&SpvEvent::TransactionReceived(Box::new(TransactionInfo {
+            txid: dashcore::Txid::from_byte_array([4u8; 32]),
             amount: 50_000,
             direction: TransactionDirection::Incoming,
             transaction_type: TransactionType::Standard,
-            addresses: vec!["Xaddr4".into()],
+            timestamp: 0,
             height: None,
-            timestamp: None,
+            fee: None,
+            addresses: vec!["Xaddr4".into()],
             block_hash: None,
             is_instant_send: true,
             is_chain_locked: false,
             label: None,
-        });
+        })));
 
         assert_eq!(state.transactions.len(), 1);
         assert!(state.transactions[0].is_instant_send);
@@ -231,37 +233,20 @@ mod tests {
         let mut state = WalletState::default();
 
         // First: mempool tx
-        state.apply_event(&SpvEvent::TransactionReceived {
-            txid: [5u8; 32],
-            amount: 100_000,
-            direction: TransactionDirection::Incoming,
-            transaction_type: TransactionType::Standard,
-            addresses: vec!["Xaddr5".into()],
-            height: None,
-            timestamp: None,
-            block_hash: None,
-            is_instant_send: false,
-            is_chain_locked: false,
-            label: None,
-        });
+        state.apply_event(&tx_event(
+            5,
+            100_000,
+            TransactionDirection::Incoming,
+            vec!["Xaddr5".into()],
+            None,
+            1700000000,
+        ));
         assert_eq!(state.transactions.len(), 1);
         assert_eq!(state.transactions[0].height, None);
         assert!(!state.transactions[0].is_chain_locked);
 
         // Second: same txid confirmed in chain-locked block (status update)
-        state.apply_event(&SpvEvent::TransactionReceived {
-            txid: [5u8; 32],
-            amount: 0,
-            direction: TransactionDirection::Incoming,
-            transaction_type: TransactionType::Standard,
-            addresses: Vec::new(),
-            height: Some(2000),
-            timestamp: Some(1700001000),
-            block_hash: None,
-            is_instant_send: false,
-            is_chain_locked: true,
-            label: None,
-        });
+        state.apply_event(&status_event(5, Some(2000), 1700001000, false, true));
 
         // Should still be one transaction, not two
         assert_eq!(state.transactions.len(), 1);
@@ -272,6 +257,39 @@ mod tests {
         // Original amount/addresses should be preserved (status update had amount=0)
         assert_eq!(tx.amount, 100_000);
         assert_eq!(tx.addresses, vec!["Xaddr5".to_string()]);
+    }
+
+    #[test]
+    fn status_update_preserves_direction_and_type() {
+        let mut state = WalletState::default();
+
+        // Original outgoing CoinJoin tx with a label
+        state.apply_event(&SpvEvent::TransactionReceived(Box::new(TransactionInfo {
+            txid: dashcore::Txid::from_byte_array([6u8; 32]),
+            amount: -75_000,
+            direction: TransactionDirection::CoinJoin,
+            transaction_type: TransactionType::CoinJoin,
+            timestamp: 1700000000,
+            height: None,
+            fee: Some(100),
+            addresses: vec!["Xmix1".into()],
+            block_hash: None,
+            is_instant_send: false,
+            is_chain_locked: false,
+            label: Some("my mix".into()),
+        })));
+
+        // Status update with hardcoded Incoming/Standard fallbacks (amount=0)
+        state.apply_event(&status_event(6, Some(3000), 1700002000, false, true));
+
+        assert_eq!(state.transactions.len(), 1);
+        let tx = &state.transactions[0];
+        assert_eq!(tx.direction, TransactionDirection::CoinJoin);
+        assert_eq!(tx.transaction_type, TransactionType::CoinJoin);
+        assert_eq!(tx.label, Some("my mix".into()));
+        assert_eq!(tx.amount, -75_000);
+        assert_eq!(tx.height, Some(3000));
+        assert!(tx.is_chain_locked);
     }
 
     #[test]
@@ -364,34 +382,24 @@ mod tests {
         let mut state = WalletState::default();
 
         // Add a confirmed tx with a recent timestamp
-        state.apply_event(&SpvEvent::TransactionReceived {
-            txid: [1u8; 32],
-            amount: 100_000,
-            direction: TransactionDirection::Incoming,
-            transaction_type: TransactionType::Standard,
-            addresses: vec!["Xaddr1".into()],
-            height: Some(1000),
-            timestamp: Some(5000),
-            block_hash: None,
-            is_instant_send: false,
-            is_chain_locked: false,
-            label: None,
-        });
+        state.apply_event(&tx_event(
+            1,
+            100_000,
+            TransactionDirection::Incoming,
+            vec!["Xaddr1".into()],
+            Some(1000),
+            5000,
+        ));
 
         // Add an unconfirmed tx with an older timestamp
-        state.apply_event(&SpvEvent::TransactionReceived {
-            txid: [2u8; 32],
-            amount: 50_000,
-            direction: TransactionDirection::Incoming,
-            transaction_type: TransactionType::Standard,
-            addresses: vec!["Xaddr2".into()],
-            height: None,
-            timestamp: Some(1000),
-            block_hash: None,
-            is_instant_send: false,
-            is_chain_locked: false,
-            label: None,
-        });
+        state.apply_event(&tx_event(
+            2,
+            50_000,
+            TransactionDirection::Incoming,
+            vec!["Xaddr2".into()],
+            None,
+            1000,
+        ));
 
         assert_eq!(state.transactions.len(), 2);
         // Unconfirmed sorts first
@@ -439,19 +447,14 @@ mod tests {
         assert_eq!(state.transactions[1].timestamp, 3000);
 
         // New unconfirmed tx arrives via event
-        state.apply_event(&SpvEvent::TransactionReceived {
-            txid: [3u8; 32],
-            amount: 50_000,
-            direction: TransactionDirection::Incoming,
-            transaction_type: TransactionType::Standard,
-            addresses: vec!["Xaddr3".into()],
-            height: None,
-            timestamp: Some(2000),
-            block_hash: None,
-            is_instant_send: false,
-            is_chain_locked: false,
-            label: None,
-        });
+        state.apply_event(&tx_event(
+            3,
+            50_000,
+            TransactionDirection::Incoming,
+            vec!["Xaddr3".into()],
+            None,
+            2000,
+        ));
 
         // Unconfirmed tx sorts to front despite older timestamp
         assert_eq!(state.transactions.len(), 3);
@@ -466,55 +469,59 @@ mod tests {
         let mut state = WalletState::default();
 
         // Confirmed tx
-        state.apply_event(&SpvEvent::TransactionReceived {
-            txid: [1u8; 32],
-            amount: 100_000,
-            direction: TransactionDirection::Incoming,
-            transaction_type: TransactionType::Standard,
-            addresses: vec!["Xaddr1".into()],
-            height: Some(500),
-            timestamp: Some(3000),
-            block_hash: None,
-            is_instant_send: false,
-            is_chain_locked: false,
-            label: None,
-        });
+        state.apply_event(&tx_event(
+            1,
+            100_000,
+            TransactionDirection::Incoming,
+            vec!["Xaddr1".into()],
+            Some(500),
+            3000,
+        ));
 
         // Unconfirmed tx (sorts first)
-        state.apply_event(&SpvEvent::TransactionReceived {
-            txid: [2u8; 32],
-            amount: 50_000,
-            direction: TransactionDirection::Incoming,
-            transaction_type: TransactionType::Standard,
-            addresses: vec!["Xaddr2".into()],
-            height: None,
-            timestamp: Some(4000),
-            block_hash: None,
-            is_instant_send: false,
-            is_chain_locked: false,
-            label: None,
-        });
+        state.apply_event(&tx_event(
+            2,
+            50_000,
+            TransactionDirection::Incoming,
+            vec!["Xaddr2".into()],
+            None,
+            4000,
+        ));
         assert_eq!(state.transactions[0].height, None);
 
         // The unconfirmed tx gets confirmed
-        state.apply_event(&SpvEvent::TransactionReceived {
-            txid: [2u8; 32],
-            amount: 0,
-            direction: TransactionDirection::Incoming,
-            transaction_type: TransactionType::Standard,
-            addresses: Vec::new(),
-            height: Some(600),
-            timestamp: Some(4000),
-            block_hash: None,
-            is_instant_send: false,
-            is_chain_locked: true,
-            label: None,
-        });
+        state.apply_event(&status_event(2, Some(600), 4000, false, true));
 
         // Both confirmed now, sorted by timestamp descending
         assert_eq!(state.transactions[0].timestamp, 4000);
         assert_eq!(state.transactions[0].height, Some(600));
         assert_eq!(state.transactions[1].timestamp, 3000);
         assert_eq!(state.transactions[1].height, Some(500));
+    }
+
+    #[test]
+    fn label_propagated_from_event() {
+        let mut state = WalletState::default();
+
+        state.apply_event(&SpvEvent::TransactionReceived(Box::new(TransactionInfo {
+            txid: dashcore::Txid::from_byte_array([7u8; 32]),
+            amount: 42_000,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
+            timestamp: 1700000000,
+            height: Some(500),
+            fee: None,
+            addresses: vec!["Xaddr7".into()],
+            block_hash: None,
+            is_instant_send: false,
+            is_chain_locked: false,
+            label: Some("payment for coffee".into()),
+        })));
+
+        assert_eq!(state.transactions.len(), 1);
+        assert_eq!(
+            state.transactions[0].label,
+            Some("payment for coffee".into())
+        );
     }
 }

--- a/src/state/wallet.rs
+++ b/src/state/wallet.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use dashcore::hashes::Hash;
 
 use crate::backend::events::SpvEvent;
-use crate::backend::types::{TransactionDirection, TransactionInfo, WalletCoreBalance};
+use crate::backend::types::{TransactionInfo, WalletCoreBalance};
 
 /// Wallet state tracked by the UI.
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -36,12 +36,15 @@ impl WalletState {
             SpvEvent::TransactionReceived {
                 txid,
                 amount,
+                direction,
+                transaction_type,
                 addresses,
                 height,
                 timestamp,
                 block_hash,
                 is_instant_send,
                 is_chain_locked,
+                label,
             } => {
                 let txid_parsed = dashcore::Txid::from_byte_array(*txid);
 
@@ -57,20 +60,17 @@ impl WalletState {
                     }
                     existing.is_instant_send = *is_instant_send;
                     existing.is_chain_locked = *is_chain_locked;
-                    // Update amount/addresses if this is a full event (not a status-only update)
+                    // Update amount/addresses/direction if this is a full event (not a status-only update)
                     if *amount != 0 {
                         existing.amount = *amount;
+                        existing.direction = *direction;
+                        existing.transaction_type = *transaction_type;
                         existing.addresses.clone_from(addresses);
+                        existing.label.clone_from(label);
                     }
                     sort_transactions(&mut self.transactions);
                     return;
                 }
-
-                let direction = if *amount >= 0 {
-                    TransactionDirection::Received
-                } else {
-                    TransactionDirection::Sent
-                };
 
                 let fallback_timestamp = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
@@ -80,7 +80,8 @@ impl WalletState {
                 let record = TransactionInfo {
                     txid: txid_parsed,
                     amount: *amount,
-                    direction,
+                    direction: *direction,
+                    transaction_type: *transaction_type,
                     timestamp: timestamp.unwrap_or(fallback_timestamp),
                     height: *height,
                     fee: None,
@@ -88,6 +89,7 @@ impl WalletState {
                     block_hash: block_hash.map(dashcore::BlockHash::from_byte_array),
                     is_instant_send: *is_instant_send,
                     is_chain_locked: *is_chain_locked,
+                    label: label.clone(),
                 };
 
                 self.transactions.push(record);
@@ -106,6 +108,8 @@ impl WalletState {
 
 #[cfg(test)]
 mod tests {
+    use crate::backend::types::{TransactionDirection, TransactionType};
+
     use super::*;
 
     #[test]
@@ -131,28 +135,34 @@ mod tests {
         state.apply_event(&SpvEvent::TransactionReceived {
             txid: [1u8; 32],
             amount: 100_000,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
             addresses: vec!["Xaddr1".into()],
             height: None,
             timestamp: Some(1000),
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: false,
+            label: None,
         });
         assert_eq!(state.transactions.len(), 1);
         assert_eq!(
             state.transactions[0].direction,
-            TransactionDirection::Received
+            TransactionDirection::Incoming
         );
 
         state.apply_event(&SpvEvent::TransactionReceived {
             txid: [2u8; 32],
             amount: -50_000,
+            direction: TransactionDirection::Outgoing,
+            transaction_type: TransactionType::Standard,
             addresses: vec!["Xaddr2".into()],
             height: None,
             timestamp: Some(2000),
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: false,
+            label: None,
         });
         assert_eq!(state.transactions.len(), 2);
         // Newer unconfirmed tx sorts first
@@ -160,7 +170,10 @@ mod tests {
             state.transactions[0].txid,
             dashcore::Txid::from_byte_array([2u8; 32])
         );
-        assert_eq!(state.transactions[0].direction, TransactionDirection::Sent);
+        assert_eq!(
+            state.transactions[0].direction,
+            TransactionDirection::Outgoing
+        );
     }
 
     #[test]
@@ -170,12 +183,15 @@ mod tests {
         state.apply_event(&SpvEvent::TransactionReceived {
             txid: [3u8; 32],
             amount: 200_000,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
             addresses: vec!["Xaddr3".into()],
             height: Some(1000),
             timestamp: Some(1700000000),
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: true,
+            label: None,
         });
 
         assert_eq!(state.transactions.len(), 1);
@@ -193,12 +209,15 @@ mod tests {
         state.apply_event(&SpvEvent::TransactionReceived {
             txid: [4u8; 32],
             amount: 50_000,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
             addresses: vec!["Xaddr4".into()],
             height: None,
             timestamp: None,
             block_hash: None,
             is_instant_send: true,
             is_chain_locked: false,
+            label: None,
         });
 
         assert_eq!(state.transactions.len(), 1);
@@ -215,12 +234,15 @@ mod tests {
         state.apply_event(&SpvEvent::TransactionReceived {
             txid: [5u8; 32],
             amount: 100_000,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
             addresses: vec!["Xaddr5".into()],
             height: None,
             timestamp: None,
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: false,
+            label: None,
         });
         assert_eq!(state.transactions.len(), 1);
         assert_eq!(state.transactions[0].height, None);
@@ -230,12 +252,15 @@ mod tests {
         state.apply_event(&SpvEvent::TransactionReceived {
             txid: [5u8; 32],
             amount: 0,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
             addresses: Vec::new(),
             height: Some(2000),
             timestamp: Some(1700001000),
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: true,
+            label: None,
         });
 
         // Should still be one transaction, not two
@@ -256,7 +281,8 @@ mod tests {
             TransactionInfo {
                 txid: dashcore::Txid::from_byte_array([1u8; 32]),
                 amount: 100,
-                direction: TransactionDirection::Received,
+                direction: TransactionDirection::Incoming,
+                transaction_type: TransactionType::Standard,
                 timestamp: 1000,
                 height: Some(500),
                 fee: None,
@@ -264,11 +290,13 @@ mod tests {
                 block_hash: None,
                 is_instant_send: false,
                 is_chain_locked: false,
+                label: None,
             },
             TransactionInfo {
                 txid: dashcore::Txid::from_byte_array([2u8; 32]),
                 amount: 200,
-                direction: TransactionDirection::Received,
+                direction: TransactionDirection::Incoming,
+                transaction_type: TransactionType::Standard,
                 timestamp: 2000,
                 height: Some(600),
                 fee: None,
@@ -276,6 +304,7 @@ mod tests {
                 block_hash: None,
                 is_instant_send: false,
                 is_chain_locked: false,
+                label: None,
             },
         ];
         state.set_transactions(txs);
@@ -298,7 +327,8 @@ mod tests {
             TransactionInfo {
                 txid: dashcore::Txid::from_byte_array([1u8; 32]),
                 amount: 100,
-                direction: TransactionDirection::Received,
+                direction: TransactionDirection::Incoming,
+                transaction_type: TransactionType::Standard,
                 timestamp: 5000,
                 height: Some(500),
                 fee: None,
@@ -306,11 +336,13 @@ mod tests {
                 block_hash: None,
                 is_instant_send: false,
                 is_chain_locked: false,
+                label: None,
             },
             TransactionInfo {
                 txid: dashcore::Txid::from_byte_array([2u8; 32]),
                 amount: 200,
-                direction: TransactionDirection::Received,
+                direction: TransactionDirection::Incoming,
+                transaction_type: TransactionType::Standard,
                 timestamp: 1000,
                 height: None,
                 fee: None,
@@ -318,6 +350,7 @@ mod tests {
                 block_hash: None,
                 is_instant_send: false,
                 is_chain_locked: false,
+                label: None,
             },
         ];
         state.set_transactions(txs);
@@ -334,24 +367,30 @@ mod tests {
         state.apply_event(&SpvEvent::TransactionReceived {
             txid: [1u8; 32],
             amount: 100_000,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
             addresses: vec!["Xaddr1".into()],
             height: Some(1000),
             timestamp: Some(5000),
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: false,
+            label: None,
         });
 
         // Add an unconfirmed tx with an older timestamp
         state.apply_event(&SpvEvent::TransactionReceived {
             txid: [2u8; 32],
             amount: 50_000,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
             addresses: vec!["Xaddr2".into()],
             height: None,
             timestamp: Some(1000),
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: false,
+            label: None,
         });
 
         assert_eq!(state.transactions.len(), 2);
@@ -369,7 +408,8 @@ mod tests {
             TransactionInfo {
                 txid: dashcore::Txid::from_byte_array([1u8; 32]),
                 amount: 100,
-                direction: TransactionDirection::Received,
+                direction: TransactionDirection::Incoming,
+                transaction_type: TransactionType::Standard,
                 timestamp: 3000,
                 height: Some(300),
                 fee: None,
@@ -377,11 +417,13 @@ mod tests {
                 block_hash: None,
                 is_instant_send: false,
                 is_chain_locked: false,
+                label: None,
             },
             TransactionInfo {
                 txid: dashcore::Txid::from_byte_array([2u8; 32]),
                 amount: 200,
-                direction: TransactionDirection::Received,
+                direction: TransactionDirection::Incoming,
+                transaction_type: TransactionType::Standard,
                 timestamp: 4000,
                 height: Some(400),
                 fee: None,
@@ -389,6 +431,7 @@ mod tests {
                 block_hash: None,
                 is_instant_send: false,
                 is_chain_locked: false,
+                label: None,
             },
         ];
         state.set_transactions(txs);
@@ -399,12 +442,15 @@ mod tests {
         state.apply_event(&SpvEvent::TransactionReceived {
             txid: [3u8; 32],
             amount: 50_000,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
             addresses: vec!["Xaddr3".into()],
             height: None,
             timestamp: Some(2000),
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: false,
+            label: None,
         });
 
         // Unconfirmed tx sorts to front despite older timestamp
@@ -423,24 +469,30 @@ mod tests {
         state.apply_event(&SpvEvent::TransactionReceived {
             txid: [1u8; 32],
             amount: 100_000,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
             addresses: vec!["Xaddr1".into()],
             height: Some(500),
             timestamp: Some(3000),
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: false,
+            label: None,
         });
 
         // Unconfirmed tx (sorts first)
         state.apply_event(&SpvEvent::TransactionReceived {
             txid: [2u8; 32],
             amount: 50_000,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
             addresses: vec!["Xaddr2".into()],
             height: None,
             timestamp: Some(4000),
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: false,
+            label: None,
         });
         assert_eq!(state.transactions[0].height, None);
 
@@ -448,12 +500,15 @@ mod tests {
         state.apply_event(&SpvEvent::TransactionReceived {
             txid: [2u8; 32],
             amount: 0,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
             addresses: Vec::new(),
             height: Some(600),
             timestamp: Some(4000),
             block_hash: None,
             is_instant_send: false,
             is_chain_locked: true,
+            label: None,
         });
 
         // Both confirmed now, sorted by timestamp descending

--- a/tests/dashd_sync/tests_native.rs
+++ b/tests/dashd_sync/tests_native.rs
@@ -230,8 +230,8 @@ async fn native_send_transaction() {
     assert_tx_unconfirmed(sent_tx_before, "sent tx before mining");
     assert_eq!(
         sent_tx_before.direction,
-        TransactionDirection::Sent,
-        "Sent tx should have Sent direction"
+        TransactionDirection::Outgoing,
+        "Sent tx should have Outgoing direction"
     );
     assert!(
         sent_tx_before.amount < 0,
@@ -267,8 +267,8 @@ async fn native_send_transaction() {
     );
     assert_eq!(
         sent_tx.direction,
-        TransactionDirection::Sent,
-        "Direction should remain Sent after confirmation"
+        TransactionDirection::Outgoing,
+        "Direction should remain Outgoing after confirmation"
     );
 
     // Verify no duplicate txids after confirmation.


### PR DESCRIPTION
## Summary
- Replace our 2-variant `TransactionDirection { Sent, Received }` with upstream's 4-variant enum (`Incoming`, `Outgoing`, `Internal`, `CoinJoin`)
- Re-export upstream `TransactionType` and add it + `label` field to `TransactionInfo`
- Simplify `SpvEvent::TransactionReceived` to carry `Box<TransactionInfo>` directly instead of scattered individual fields
- Remove redundant `TxFilter` enum — use `Option<TransactionDirection>` for filter tabs
- Fix transaction list styling: Internal/CoinJoin use neutral colors instead of green (received)
- Add label to `matches_search` so labeled transactions are searchable
- Guard timestamp overwrites on status-only updates
- Extract duplicated FFI label extraction into `extract_ffi_label` helper
- Deduplicate `TransactionInfo` construction in mock backend

Closes #140