### PR TITLE
feat: show direction and type badges in transaction list

### DIFF
--- a/src/screens/dashboard.rs
+++ b/src/screens/dashboard.rs
@@ -114,7 +114,9 @@ pub fn Dashboard() -> Element {
                                                     }
                                                 }
                                                 if view.is_instant_send {
-                                                    span { class: "bg-dash text-foreground text-xs rounded-full px-2 py-0.5", "IS" }
+                                                    span { class: "bg-dash text-foreground text-xs rounded-full px-2 py-0.5",
+                                                        "IS"
+                                                    }
                                                 }
                                                 if view.is_chain_locked {
                                                     span { class: "bg-chainlock text-foreground text-xs rounded-full px-2 py-0.5",

--- a/src/screens/dashboard.rs
+++ b/src/screens/dashboard.rs
@@ -1,6 +1,5 @@
 use dioxus::prelude::*;
 
-use crate::backend::types::TransactionDirection;
 use crate::config::AppConfig;
 use crate::router::Route;
 use crate::state::network::NetworkInfo;
@@ -73,13 +72,10 @@ pub fn Dashboard() -> Element {
                             {
                                 let view = format_transaction(tx, current_height, unit);
                                 let bg = if i % 2 == 0 { "bg-card" } else { "bg-surface-alt" };
-                                let border = match tx.direction {
-                                    TransactionDirection::Outgoing => "border-error",
-                                    TransactionDirection::Incoming => "border-success",
-                                    TransactionDirection::Internal | TransactionDirection::CoinJoin => {
-                                        "border-muted"
-                                    }
-                                };
+                                let border = view.border_class;
+                                let icon_class = view.direction_icon_class;
+                                let icon = view.direction_icon;
+                                let amount_class = view.amount_class;
                                 let is_expanded = *expanded_txid.read() == Some(tx.txid);
                                 let txid = tx.txid;
                                 let address_short = format_address_responsive(
@@ -102,20 +98,7 @@ pub fn Dashboard() -> Element {
 
 
                                             div { class: "flex items-center gap-3 min-w-0 flex-1",
-                                                span {
-                                                    class: match tx.direction {
-                                                        TransactionDirection::Outgoing => "text-error text-lg shrink-0",
-                                                        TransactionDirection::Incoming => "text-success text-lg shrink-0",
-                                                        TransactionDirection::Internal | TransactionDirection::CoinJoin => {
-                                                            "text-muted text-lg shrink-0"
-                                                        }
-                                                    },
-                                                    match tx.direction {
-                                                        TransactionDirection::Outgoing => "▲",
-                                                        TransactionDirection::Incoming => "▼",
-                                                        TransactionDirection::Internal | TransactionDirection::CoinJoin => "⇄",
-                                                    }
-                                                }
+                                                span { class: icon_class, "{icon}" }
                                                 div { class: "min-w-0",
                                                     p { class: "font-mono text-sm truncate", "{address_short}" }
                                                     p { class: "text-disabled text-xs", "{view.timestamp_display}" }
@@ -124,17 +107,13 @@ pub fn Dashboard() -> Element {
 
                                             div { class: "text-right flex items-center gap-2",
                                                 div {
-                                                    p {
-                                                        class: match tx.direction {
-                                                            TransactionDirection::Outgoing => "text-error font-medium",
-                                                            TransactionDirection::Incoming => "text-success font-medium",
-                                                            TransactionDirection::Internal | TransactionDirection::CoinJoin => {
-                                                                "text-muted font-medium"
-                                                            }
-                                                        },
-                                                        "{view.amount_display}"
-                                                    }
+                                                    p { class: amount_class, "{view.amount_display}" }
                                                     p { class: "text-disabled text-xs", "{view.confirmations_display}" }
+                                                }
+                                                if let Some(badge) = view.type_badge {
+                                                    span { class: "bg-surface-alt text-muted text-xs rounded-full px-2 py-0.5 border border-edge",
+                                                        "{badge}"
+                                                    }
                                                 }
                                                 if view.is_instant_send {
                                                     span { class: "bg-dash text-xs rounded-full px-2 py-0.5", "IS" }

--- a/src/screens/dashboard.rs
+++ b/src/screens/dashboard.rs
@@ -114,7 +114,7 @@ pub fn Dashboard() -> Element {
                                                     }
                                                 }
                                                 if view.is_instant_send {
-                                                    span { class: "bg-dash text-xs rounded-full px-2 py-0.5", "IS" }
+                                                    span { class: "bg-dash text-foreground text-xs rounded-full px-2 py-0.5", "IS" }
                                                 }
                                                 if view.is_chain_locked {
                                                     span { class: "bg-chainlock text-foreground text-xs rounded-full px-2 py-0.5",

--- a/src/screens/dashboard.rs
+++ b/src/screens/dashboard.rs
@@ -3,9 +3,7 @@ use dioxus::prelude::*;
 use crate::config::AppConfig;
 use crate::router::Route;
 use crate::state::network::NetworkInfo;
-use crate::state::view_models::{
-    format_address_responsive, format_balance, format_timestamp_absolute, format_transaction,
-};
+use crate::state::view_models::{format_address_responsive, format_balance, format_transaction};
 use crate::state::wallet::WalletState;
 
 const DASHBOARD_TX_LIMIT: usize = 5;
@@ -131,17 +129,17 @@ pub fn Dashboard() -> Element {
 
                                                 div { class: "flex justify-between",
                                                     span { class: "text-muted", "Transaction ID" }
-                                                    span { class: "font-mono text-xs select-all", "{tx.txid}" }
+                                                    span { class: "font-mono text-xs select-all", "{view.txid_hex}" }
                                                 }
 
-                                                if let Some(hash) = &tx.block_hash {
+                                                if let Some(hash) = &view.block_hash_display {
                                                     div { class: "flex justify-between",
                                                         span { class: "text-muted", "Block Hash" }
                                                         span { class: "font-mono text-xs select-all", "{hash}" }
                                                     }
                                                 }
 
-                                                if let Some(h) = tx.height {
+                                                if let Some(h) = &view.height_display {
                                                     div { class: "flex justify-between",
                                                         span { class: "text-muted", "Block Height" }
                                                         span { "{h}" }
@@ -150,13 +148,13 @@ pub fn Dashboard() -> Element {
 
                                                 div { class: "flex justify-between",
                                                     span { class: "text-muted", "Date" }
-                                                    span { "{format_timestamp_absolute(tx.timestamp)}" }
+                                                    span { "{view.absolute_date}" }
                                                 }
 
-                                                if let Some(fee) = tx.fee {
+                                                if let Some(fee) = &view.fee_display {
                                                     div { class: "flex justify-between",
                                                         span { class: "text-muted", "Fee" }
-                                                        span { "{format_balance(fee, unit)}" }
+                                                        span { "{fee}" }
                                                     }
                                                 }
 

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -4,8 +4,8 @@ use crate::backend::types::{TransactionDirection, TransactionInfo};
 use crate::config::AppConfig;
 use crate::state::network::NetworkInfo;
 use crate::state::view_models::{
-    format_address_responsive, format_balance, format_timestamp_absolute, format_transaction,
-    matches_search,
+    TransactionView, format_address_responsive, format_balance, format_timestamp_absolute,
+    format_transaction, matches_search,
 };
 use crate::state::wallet::WalletState;
 
@@ -145,14 +145,6 @@ pub fn Transactions() -> Element {
                         {
                             let view = format_transaction(tx, current_height, unit);
                             let bg = if i % 2 == 0 { "bg-card" } else { "bg-surface-alt" };
-                            let border = match tx.direction {
-                                TransactionDirection::Outgoing => "border-error",
-                                TransactionDirection::Incoming => "border-success",
-
-                                TransactionDirection::Internal | TransactionDirection::CoinJoin => {
-                                    "border-muted"
-                                }
-                            };
                             let address_short = format_address_responsive(
                                 &tx.addresses.first().cloned().unwrap_or_default(),
                                 30,
@@ -162,119 +154,25 @@ pub fn Transactions() -> Element {
                             let txid = tx.txid;
                             let tx = (*tx).clone();
                             rsx! {
-                                div {
-                                    div {
-                                        class: "flex items-center justify-between {bg} border-l-4 {border} hover:bg-hover rounded-lg p-3 transition-colors cursor-pointer",
-                                        onclick: move |_| {
-                                            if *expanded_txid.read() == Some(txid) {
-                                                expanded_txid.set(None);
-                                            } else {
-                                                expanded_txid.set(Some(txid));
-                                            }
-                                        },
-
-
-
-                                        div { class: "flex items-center gap-3 min-w-0",
-                                            span {
-                                                class: match tx.direction {
-                                                    TransactionDirection::Outgoing => "text-error text-lg flex-shrink-0",
-                                                    TransactionDirection::Incoming => "text-success text-lg flex-shrink-0",
-                                                    TransactionDirection::Internal | TransactionDirection::CoinJoin => {
-                                                        "text-muted text-lg flex-shrink-0"
-                                                    }
-                                                },
-                                                match tx.direction {
-                                                    TransactionDirection::Outgoing => "▲",
-                                                    TransactionDirection::Incoming => "▼",
-                                                    TransactionDirection::Internal | TransactionDirection::CoinJoin => "⇄",
-                                                }
-                                            }
-                                            div { class: "min-w-0",
-                                                p { class: "font-mono text-sm truncate", "{address_short}" }
-                                                p { class: "text-disabled text-xs", "{view.timestamp_display}" }
-                                            }
+                                TransactionRow {
+                                    view,
+                                    bg,
+                                    address_short,
+                                    confirmations,
+                                    height: tx.height,
+                                    is_expanded,
+                                    block_hash: tx.block_hash,
+                                    timestamp: tx.timestamp,
+                                    fee: tx.fee,
+                                    addresses: tx.addresses.clone(),
+                                    unit,
+                                    onclick: move |_| {
+                                        if *expanded_txid.read() == Some(txid) {
+                                            expanded_txid.set(None);
+                                        } else {
+                                            expanded_txid.set(Some(txid));
                                         }
-
-                                        div { class: "text-right flex items-center gap-2 flex-shrink-0",
-                                            div {
-                                                p {
-                                                    class: match tx.direction {
-                                                        TransactionDirection::Outgoing => "text-error font-medium",
-                                                        TransactionDirection::Incoming => "text-success font-medium",
-                                                        TransactionDirection::Internal | TransactionDirection::CoinJoin => {
-                                                            "text-muted font-medium"
-                                                        }
-                                                    },
-                                                    "{view.amount_display}"
-                                                }
-                                                p { class: "text-disabled text-xs",
-                                                    if confirmations > 0 {
-                                                        if let Some(h) = tx.height {
-                                                            "{confirmations} confirmations (block {h})"
-                                                        } else {
-                                                            "{view.confirmations_display}"
-                                                        }
-                                                    } else {
-                                                        "Unconfirmed"
-                                                    }
-                                                }
-                                            }
-                                            if view.is_instant_send {
-                                                span { class: "bg-dash text-foreground text-xs rounded-full px-2 py-0.5",
-                                                    "IS"
-                                                }
-                                            }
-                                            if view.is_chain_locked {
-                                                span { class: "bg-chainlock text-foreground text-xs rounded-full px-2 py-0.5",
-                                                    "CL"
-                                                }
-                                            }
-                                        }
-                                    }
-
-                                    if is_expanded {
-                                        div { class: "bg-surface-alt rounded-b-lg px-4 py-3 -mt-1 mb-1 border-l-4 {border} text-sm space-y-2",
-
-                                            div { class: "flex justify-between",
-                                                span { class: "text-muted", "Transaction ID" }
-                                                span { class: "font-mono text-xs select-all", "{tx.txid}" }
-                                            }
-
-                                            if let Some(hash) = &tx.block_hash {
-                                                div { class: "flex justify-between",
-                                                    span { class: "text-muted", "Block Hash" }
-                                                    span { class: "font-mono text-xs select-all", "{hash}" }
-                                                }
-                                            }
-
-                                            if let Some(h) = tx.height {
-                                                div { class: "flex justify-between",
-                                                    span { class: "text-muted", "Block Height" }
-                                                    span { "{h}" }
-                                                }
-                                            }
-
-                                            div { class: "flex justify-between",
-                                                span { class: "text-muted", "Date" }
-                                                span { "{format_timestamp_absolute(tx.timestamp)}" }
-                                            }
-
-                                            if let Some(fee) = tx.fee {
-                                                div { class: "flex justify-between",
-                                                    span { class: "text-muted", "Fee" }
-                                                    span { "{format_balance(fee, unit)}" }
-                                                }
-                                            }
-
-                                            div {
-                                                span { class: "text-muted block mb-1", "Addresses" }
-                                                for addr in &tx.addresses {
-                                                    p { class: "font-mono text-xs select-all", "{addr}" }
-                                                }
-                                            }
-                                        }
-                                    }
+                                    },
                                 }
                             }
                         }
@@ -294,6 +192,119 @@ pub fn Transactions() -> Element {
                         }
                     } else if total_filtered > PAGE_SIZE {
                         p { class: "text-disabled text-sm py-2", "All transactions loaded" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn TransactionRow(
+    view: TransactionView,
+    bg: &'static str,
+    address_short: String,
+    confirmations: u32,
+    height: Option<u32>,
+    is_expanded: bool,
+    block_hash: Option<dashcore::BlockHash>,
+    timestamp: u64,
+    fee: Option<u64>,
+    addresses: Vec<String>,
+    unit: &'static str,
+    onclick: EventHandler<MouseEvent>,
+) -> Element {
+    let border = view.border_class;
+    let icon_class = view.direction_icon_class;
+    let icon = view.direction_icon;
+    let amount_class = view.amount_class;
+
+    rsx! {
+        div {
+            div {
+                class: "flex items-center justify-between {bg} border-l-4 {border} hover:bg-hover rounded-lg p-3 transition-colors cursor-pointer",
+                onclick: move |e| onclick.call(e),
+
+                div { class: "flex items-center gap-3 min-w-0",
+                    span { class: icon_class, "{icon}" }
+                    div { class: "min-w-0",
+                        p { class: "font-mono text-sm truncate", "{address_short}" }
+                        p { class: "text-disabled text-xs", "{view.timestamp_display}" }
+                    }
+                }
+
+                div { class: "text-right flex items-center gap-2 flex-shrink-0",
+                    div {
+                        p { class: amount_class, "{view.amount_display}" }
+                        p { class: "text-disabled text-xs",
+                            if confirmations > 0 {
+                                if let Some(h) = height {
+                                    "{confirmations} confirmations (block {h})"
+                                } else {
+                                    "{view.confirmations_display}"
+                                }
+                            } else {
+                                "Unconfirmed"
+                            }
+                        }
+                    }
+                    if let Some(badge) = view.type_badge {
+                        span { class: "bg-surface-alt text-muted text-xs rounded-full px-2 py-0.5 border border-edge",
+                            "{badge}"
+                        }
+                    }
+                    if view.is_instant_send {
+                        span { class: "bg-dash text-foreground text-xs rounded-full px-2 py-0.5",
+                            "IS"
+                        }
+                    }
+                    if view.is_chain_locked {
+                        span { class: "bg-chainlock text-foreground text-xs rounded-full px-2 py-0.5",
+                            "CL"
+                        }
+                    }
+                }
+            }
+
+            if is_expanded {
+                div { class: "bg-surface-alt rounded-b-lg px-4 py-3 -mt-1 mb-1 border-l-4 {border} text-sm space-y-2",
+
+                    div { class: "flex justify-between",
+                        span { class: "text-muted", "Transaction ID" }
+                        span { class: "font-mono text-xs select-all", "{view.txid_hex}" }
+                    }
+
+                    if let Some(hash) = &block_hash {
+                        div { class: "flex justify-between",
+                            span { class: "text-muted", "Block Hash" }
+                            span { class: "font-mono text-xs select-all", "{hash}" }
+                        }
+                    }
+
+                    if let Some(h) = height {
+                        div { class: "flex justify-between",
+                            span { class: "text-muted", "Block Height" }
+                            span { "{h}" }
+                        }
+                    }
+
+                    div { class: "flex justify-between",
+                        span { class: "text-muted", "Date" }
+                        span { "{format_timestamp_absolute(timestamp)}" }
+                    }
+
+                    if let Some(fee) = fee {
+                        div { class: "flex justify-between",
+                            span { class: "text-muted", "Fee" }
+                            span { "{format_balance(fee, unit)}" }
+                        }
+                    }
+
+                    div {
+                        span { class: "text-muted block mb-1", "Addresses" }
+                        for addr in &addresses {
+                            p { class: "font-mono text-xs select-all", "{addr}" }
+                        }
                     }
                 }
             }

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -4,8 +4,7 @@ use crate::backend::types::{TransactionDirection, TransactionInfo};
 use crate::config::AppConfig;
 use crate::state::network::NetworkInfo;
 use crate::state::view_models::{
-    TransactionView, format_address_responsive, format_balance, format_timestamp_absolute,
-    format_transaction, matches_search,
+    TransactionView, format_address_responsive, format_transaction, matches_search,
 };
 use crate::state::wallet::WalletState;
 
@@ -161,11 +160,7 @@ pub fn Transactions() -> Element {
                                     confirmations,
                                     height: tx.height,
                                     is_expanded,
-                                    block_hash: tx.block_hash,
-                                    timestamp: tx.timestamp,
-                                    fee: tx.fee,
                                     addresses: tx.addresses.clone(),
-                                    unit,
                                     onclick: move |_| {
                                         if *expanded_txid.read() == Some(txid) {
                                             expanded_txid.set(None);
@@ -207,11 +202,7 @@ fn TransactionRow(
     confirmations: u32,
     height: Option<u32>,
     is_expanded: bool,
-    block_hash: Option<dashcore::BlockHash>,
-    timestamp: u64,
-    fee: Option<u64>,
     addresses: Vec<String>,
-    unit: &'static str,
     onclick: EventHandler<MouseEvent>,
 ) -> Element {
     let border = view.border_class;
@@ -274,14 +265,14 @@ fn TransactionRow(
                         span { class: "font-mono text-xs select-all", "{view.txid_hex}" }
                     }
 
-                    if let Some(hash) = &block_hash {
+                    if let Some(hash) = &view.block_hash_display {
                         div { class: "flex justify-between",
                             span { class: "text-muted", "Block Hash" }
                             span { class: "font-mono text-xs select-all", "{hash}" }
                         }
                     }
 
-                    if let Some(h) = height {
+                    if let Some(h) = &view.height_display {
                         div { class: "flex justify-between",
                             span { class: "text-muted", "Block Height" }
                             span { "{h}" }
@@ -290,13 +281,13 @@ fn TransactionRow(
 
                     div { class: "flex justify-between",
                         span { class: "text-muted", "Date" }
-                        span { "{format_timestamp_absolute(timestamp)}" }
+                        span { "{view.absolute_date}" }
                     }
 
-                    if let Some(fee) = fee {
+                    if let Some(fee) = &view.fee_display {
                         div { class: "flex justify-between",
                             span { class: "text-muted", "Fee" }
-                            span { "{format_balance(fee, unit)}" }
+                            span { "{fee}" }
                         }
                     }
 

--- a/src/state/view_models.rs
+++ b/src/state/view_models.rs
@@ -511,6 +511,10 @@ mod tests {
         let view = format_transaction(&tx, 1000, "DASH");
         assert_eq!(view.direction_label, "Received");
         assert_eq!(view.direction_icon, "▼");
+        assert_eq!(
+            view.direction_icon_class,
+            "text-success text-lg flex-shrink-0"
+        );
         assert_eq!(view.border_class, "border-success");
         assert_eq!(view.amount_class, "text-success font-medium");
         assert_eq!(view.type_badge, None);
@@ -541,6 +545,10 @@ mod tests {
         let view = format_transaction(&tx, 1000, "DASH");
         assert_eq!(view.direction_label, "Sent");
         assert_eq!(view.direction_icon, "▲");
+        assert_eq!(
+            view.direction_icon_class,
+            "text-error text-lg flex-shrink-0"
+        );
         assert_eq!(view.border_class, "border-error");
         assert_eq!(view.amount_class, "text-error font-medium");
         assert_eq!(view.type_badge, None);
@@ -589,6 +597,10 @@ mod tests {
         let view = format_transaction(&tx, 1000, "DASH");
         assert_eq!(view.direction_label, "Internal");
         assert_eq!(view.direction_icon, "⇄");
+        assert_eq!(
+            view.direction_icon_class,
+            "text-muted text-lg flex-shrink-0"
+        );
         assert_eq!(view.border_class, "border-muted");
         assert_eq!(view.amount_class, "text-muted font-medium");
         assert_eq!(view.type_badge, None);
@@ -614,6 +626,10 @@ mod tests {
         let view = format_transaction(&tx, 1000, "DASH");
         assert_eq!(view.direction_label, "CoinJoin");
         assert_eq!(view.direction_icon, "⇄");
+        assert_eq!(
+            view.direction_icon_class,
+            "text-muted text-lg flex-shrink-0"
+        );
         assert_eq!(view.border_class, "border-muted");
         assert_eq!(view.type_badge, Some("CoinJoin"));
     }

--- a/src/state/view_models.rs
+++ b/src/state/view_models.rs
@@ -284,7 +284,7 @@ pub fn format_transaction(
             ),
             TransactionDirection::CoinJoin => (
                 "CoinJoin",
-                "\u{21c4}",
+                "\u{21cb}",
                 "text-muted text-lg flex-shrink-0",
                 "border-muted",
                 "text-muted font-medium",
@@ -644,7 +644,7 @@ mod tests {
 
         let view = format_transaction(&tx, 1000, "DASH");
         assert_eq!(view.direction_label, "CoinJoin");
-        assert_eq!(view.direction_icon, "⇄");
+        assert_eq!(view.direction_icon, "⇋");
         assert_eq!(
             view.direction_icon_class,
             "text-muted text-lg flex-shrink-0"

--- a/src/state/view_models.rs
+++ b/src/state/view_models.rs
@@ -227,7 +227,6 @@ pub struct TransactionView {
     pub amount_display: String,
     pub timestamp_display: String,
     pub confirmations_display: String,
-    pub address_short: String,
     pub is_instant_send: bool,
     pub is_chain_locked: bool,
 }
@@ -298,12 +297,6 @@ pub fn format_transaction(
     } else {
         format!("{confirmations} confirmations")
     };
-    let address_short = tx
-        .addresses
-        .first()
-        .map(|a| format_address_short(a))
-        .unwrap_or_default();
-
     TransactionView {
         txid_hex,
         direction_label,
@@ -315,7 +308,6 @@ pub fn format_transaction(
         amount_display,
         timestamp_display,
         confirmations_display,
-        address_short,
         is_instant_send: tx.is_instant_send,
         is_chain_locked: tx.is_chain_locked,
     }
@@ -524,7 +516,6 @@ mod tests {
         assert_eq!(view.type_badge, None);
         assert_eq!(view.amount_display, "+1.0 DASH");
         assert_eq!(view.confirmations_display, "7 confirmations");
-        assert_eq!(view.address_short, "XqN8...BGsP");
         assert!(view.is_instant_send);
         assert!(!view.is_chain_locked);
         assert_eq!(view.txid_hex.len(), 64);
@@ -576,27 +567,6 @@ mod tests {
 
         let view = format_transaction(&tx, 1000, "tDASH");
         assert_eq!(view.amount_display, "+1.0 tDASH");
-    }
-
-    #[test]
-    fn format_transaction_no_addresses() {
-        let tx = TransactionInfo {
-            txid: dashcore::Txid::from_byte_array([0; 32]),
-            amount: 0,
-            direction: TransactionDirection::Incoming,
-            transaction_type: TransactionType::Standard,
-            timestamp: 0,
-            height: None,
-            fee: None,
-            addresses: vec![],
-            block_hash: None,
-            is_instant_send: false,
-            is_chain_locked: false,
-            label: None,
-        };
-
-        let view = format_transaction(&tx, 0, "DASH");
-        assert_eq!(view.address_short, "");
     }
 
     #[test]
@@ -689,6 +659,33 @@ mod tests {
             )
             .type_badge,
             Some("ProReg")
+        );
+        assert_eq!(
+            format_transaction(
+                &make_tx(TransactionType::ProviderUpdateRegistrar),
+                1000,
+                "DASH"
+            )
+            .type_badge,
+            Some("ProUpReg")
+        );
+        assert_eq!(
+            format_transaction(
+                &make_tx(TransactionType::ProviderUpdateService),
+                1000,
+                "DASH"
+            )
+            .type_badge,
+            Some("ProUpServ")
+        );
+        assert_eq!(
+            format_transaction(
+                &make_tx(TransactionType::ProviderUpdateRevocation),
+                1000,
+                "DASH"
+            )
+            .type_badge,
+            Some("ProUpRev")
         );
         assert_eq!(
             format_transaction(&make_tx(TransactionType::Ignored), 1000, "DASH").type_badge,

--- a/src/state/view_models.rs
+++ b/src/state/view_models.rs
@@ -236,9 +236,16 @@ pub struct TransactionView {
 }
 
 /// Derive the type badge label for non-standard transaction types.
-fn type_badge_label(tx_type: TransactionType) -> Option<&'static str> {
+///
+/// Returns `None` when the badge would be redundant with the direction label
+/// (e.g., CoinJoin direction already shows "CoinJoin").
+fn type_badge_label(
+    tx_type: TransactionType,
+    direction: TransactionDirection,
+) -> Option<&'static str> {
     match tx_type {
         TransactionType::Standard => None,
+        TransactionType::CoinJoin if direction == TransactionDirection::CoinJoin => None,
         TransactionType::CoinJoin => Some("CoinJoin"),
         TransactionType::Coinbase => Some("Coinbase"),
         TransactionType::AssetLock => Some("AssetLock"),
@@ -291,7 +298,7 @@ pub fn format_transaction(
             ),
         };
 
-    let type_badge = type_badge_label(tx.transaction_type);
+    let type_badge = type_badge_label(tx.transaction_type, tx.direction);
 
     let amount_display = format_amount(tx.amount, unit);
     let timestamp_display = format_timestamp(tx.timestamp);
@@ -650,7 +657,7 @@ mod tests {
             "text-muted text-lg flex-shrink-0"
         );
         assert_eq!(view.border_class, "border-muted");
-        assert_eq!(view.type_badge, Some("CoinJoin"));
+        assert_eq!(view.type_badge, None);
     }
 
     #[test]

--- a/src/state/view_models.rs
+++ b/src/state/view_models.rs
@@ -226,7 +226,11 @@ pub struct TransactionView {
     pub type_badge: Option<&'static str>,
     pub amount_display: String,
     pub timestamp_display: String,
+    pub absolute_date: String,
     pub confirmations_display: String,
+    pub fee_display: Option<String>,
+    pub block_hash_display: Option<String>,
+    pub height_display: Option<String>,
     pub is_instant_send: bool,
     pub is_chain_locked: bool,
 }
@@ -291,12 +295,17 @@ pub fn format_transaction(
 
     let amount_display = format_amount(tx.amount, unit);
     let timestamp_display = format_timestamp(tx.timestamp);
+    let absolute_date = format_timestamp_absolute(tx.timestamp);
     let confirmations = tx.confirmations(current_height);
     let confirmations_display = if confirmations == 0 {
         "Unconfirmed".to_string()
     } else {
         format!("{confirmations} confirmations")
     };
+    let fee_display = tx.fee.map(|f| format_balance(f, unit));
+    let block_hash_display = tx.block_hash.map(|h| h.to_string());
+    let height_display = tx.height.map(|h| h.to_string());
+
     TransactionView {
         txid_hex,
         direction_label,
@@ -307,7 +316,11 @@ pub fn format_transaction(
         type_badge,
         amount_display,
         timestamp_display,
+        absolute_date,
         confirmations_display,
+        fee_display,
+        block_hash_display,
+        height_display,
         is_instant_send: tx.is_instant_send,
         is_chain_locked: tx.is_chain_locked,
     }
@@ -520,6 +533,10 @@ mod tests {
         assert_eq!(view.type_badge, None);
         assert_eq!(view.amount_display, "+1.0 DASH");
         assert_eq!(view.confirmations_display, "7 confirmations");
+        assert_eq!(view.absolute_date, "2023-11-14 22:13:20");
+        assert_eq!(view.fee_display, None);
+        assert_eq!(view.block_hash_display, None);
+        assert_eq!(view.height_display, Some("994".to_string()));
         assert!(view.is_instant_send);
         assert!(!view.is_chain_locked);
         assert_eq!(view.txid_hex.len(), 64);
@@ -554,6 +571,8 @@ mod tests {
         assert_eq!(view.type_badge, None);
         assert_eq!(view.amount_display, "-0.5 DASH");
         assert_eq!(view.confirmations_display, "Unconfirmed");
+        assert_eq!(view.fee_display, Some("0.00000226 DASH".to_string()));
+        assert_eq!(view.height_display, None);
     }
 
     #[test]

--- a/src/state/view_models.rs
+++ b/src/state/view_models.rs
@@ -1,4 +1,4 @@
-use crate::backend::types::{TransactionDirection, TransactionInfo};
+use crate::backend::types::{TransactionDirection, TransactionInfo, TransactionType};
 
 const SATS_PER_DASH: u64 = 100_000_000;
 
@@ -219,12 +219,33 @@ pub fn matches_search(tx: &TransactionInfo, query: &str, unit: &str) -> bool {
 pub struct TransactionView {
     pub txid_hex: String,
     pub direction_label: &'static str,
+    pub direction_icon: &'static str,
+    pub direction_icon_class: &'static str,
+    pub border_class: &'static str,
+    pub amount_class: &'static str,
+    pub type_badge: Option<&'static str>,
     pub amount_display: String,
     pub timestamp_display: String,
     pub confirmations_display: String,
     pub address_short: String,
     pub is_instant_send: bool,
     pub is_chain_locked: bool,
+}
+
+/// Derive the type badge label for non-standard transaction types.
+fn type_badge_label(tx_type: TransactionType) -> Option<&'static str> {
+    match tx_type {
+        TransactionType::Standard => None,
+        TransactionType::CoinJoin => Some("CoinJoin"),
+        TransactionType::Coinbase => Some("Coinbase"),
+        TransactionType::AssetLock => Some("AssetLock"),
+        TransactionType::AssetUnlock => Some("AssetUnlock"),
+        TransactionType::ProviderRegistration => Some("ProReg"),
+        TransactionType::ProviderUpdateRegistrar => Some("ProUpReg"),
+        TransactionType::ProviderUpdateService => Some("ProUpServ"),
+        TransactionType::ProviderUpdateRevocation => Some("ProUpRev"),
+        TransactionType::Ignored => None,
+    }
 }
 
 /// Convert a transaction record to a display-ready view.
@@ -234,12 +255,41 @@ pub fn format_transaction(
     unit: &str,
 ) -> TransactionView {
     let txid_hex = tx.txid.to_string();
-    let direction_label = match tx.direction {
-        TransactionDirection::Outgoing => "Sent",
-        TransactionDirection::Incoming => "Received",
-        TransactionDirection::Internal => "Internal",
-        TransactionDirection::CoinJoin => "CoinJoin",
-    };
+
+    let (direction_label, direction_icon, direction_icon_class, border_class, amount_class) =
+        match tx.direction {
+            TransactionDirection::Incoming => (
+                "Received",
+                "\u{25bc}",
+                "text-success text-lg flex-shrink-0",
+                "border-success",
+                "text-success font-medium",
+            ),
+            TransactionDirection::Outgoing => (
+                "Sent",
+                "\u{25b2}",
+                "text-error text-lg flex-shrink-0",
+                "border-error",
+                "text-error font-medium",
+            ),
+            TransactionDirection::Internal => (
+                "Internal",
+                "\u{21c4}",
+                "text-muted text-lg flex-shrink-0",
+                "border-muted",
+                "text-muted font-medium",
+            ),
+            TransactionDirection::CoinJoin => (
+                "CoinJoin",
+                "\u{21c4}",
+                "text-muted text-lg flex-shrink-0",
+                "border-muted",
+                "text-muted font-medium",
+            ),
+        };
+
+    let type_badge = type_badge_label(tx.transaction_type);
+
     let amount_display = format_amount(tx.amount, unit);
     let timestamp_display = format_timestamp(tx.timestamp);
     let confirmations = tx.confirmations(current_height);
@@ -257,6 +307,11 @@ pub fn format_transaction(
     TransactionView {
         txid_hex,
         direction_label,
+        direction_icon,
+        direction_icon_class,
+        border_class,
+        amount_class,
+        type_badge,
         amount_display,
         timestamp_display,
         confirmations_display,
@@ -463,6 +518,10 @@ mod tests {
 
         let view = format_transaction(&tx, 1000, "DASH");
         assert_eq!(view.direction_label, "Received");
+        assert_eq!(view.direction_icon, "▼");
+        assert_eq!(view.border_class, "border-success");
+        assert_eq!(view.amount_class, "text-success font-medium");
+        assert_eq!(view.type_badge, None);
         assert_eq!(view.amount_display, "+1.0 DASH");
         assert_eq!(view.confirmations_display, "7 confirmations");
         assert_eq!(view.address_short, "XqN8...BGsP");
@@ -490,6 +549,10 @@ mod tests {
 
         let view = format_transaction(&tx, 1000, "DASH");
         assert_eq!(view.direction_label, "Sent");
+        assert_eq!(view.direction_icon, "▲");
+        assert_eq!(view.border_class, "border-error");
+        assert_eq!(view.amount_class, "text-error font-medium");
+        assert_eq!(view.type_badge, None);
         assert_eq!(view.amount_display, "-0.5 DASH");
         assert_eq!(view.confirmations_display, "Unconfirmed");
     }
@@ -534,6 +597,103 @@ mod tests {
 
         let view = format_transaction(&tx, 0, "DASH");
         assert_eq!(view.address_short, "");
+    }
+
+    #[test]
+    fn format_transaction_internal() {
+        let tx = TransactionInfo {
+            txid: dashcore::Txid::from_byte_array([0xDD; 32]),
+            amount: 0,
+            direction: TransactionDirection::Internal,
+            transaction_type: TransactionType::Standard,
+            timestamp: 1700000000,
+            height: Some(500),
+            fee: Some(226),
+            addresses: vec!["yInternalAddr".into()],
+            block_hash: None,
+            is_instant_send: false,
+            is_chain_locked: false,
+            label: None,
+        };
+
+        let view = format_transaction(&tx, 1000, "DASH");
+        assert_eq!(view.direction_label, "Internal");
+        assert_eq!(view.direction_icon, "⇄");
+        assert_eq!(view.border_class, "border-muted");
+        assert_eq!(view.amount_class, "text-muted font-medium");
+        assert_eq!(view.type_badge, None);
+    }
+
+    #[test]
+    fn format_transaction_coinjoin() {
+        let tx = TransactionInfo {
+            txid: dashcore::Txid::from_byte_array([0xEE; 32]),
+            amount: -25_000_000,
+            direction: TransactionDirection::CoinJoin,
+            transaction_type: TransactionType::CoinJoin,
+            timestamp: 1700000000,
+            height: Some(500),
+            fee: Some(100),
+            addresses: vec!["yMixAddr".into()],
+            block_hash: None,
+            is_instant_send: false,
+            is_chain_locked: false,
+            label: None,
+        };
+
+        let view = format_transaction(&tx, 1000, "DASH");
+        assert_eq!(view.direction_label, "CoinJoin");
+        assert_eq!(view.direction_icon, "⇄");
+        assert_eq!(view.border_class, "border-muted");
+        assert_eq!(view.type_badge, Some("CoinJoin"));
+    }
+
+    #[test]
+    fn format_transaction_type_badges() {
+        let make_tx = |tx_type: TransactionType| TransactionInfo {
+            txid: dashcore::Txid::from_byte_array([0xFF; 32]),
+            amount: 100_000_000,
+            direction: TransactionDirection::Incoming,
+            transaction_type: tx_type,
+            timestamp: 1700000000,
+            height: Some(500),
+            fee: None,
+            addresses: vec![],
+            block_hash: None,
+            is_instant_send: false,
+            is_chain_locked: false,
+            label: None,
+        };
+
+        assert_eq!(
+            format_transaction(&make_tx(TransactionType::Standard), 1000, "DASH").type_badge,
+            None
+        );
+        assert_eq!(
+            format_transaction(&make_tx(TransactionType::Coinbase), 1000, "DASH").type_badge,
+            Some("Coinbase")
+        );
+        assert_eq!(
+            format_transaction(&make_tx(TransactionType::AssetLock), 1000, "DASH").type_badge,
+            Some("AssetLock")
+        );
+        assert_eq!(
+            format_transaction(&make_tx(TransactionType::AssetUnlock), 1000, "DASH").type_badge,
+            Some("AssetUnlock")
+        );
+        assert_eq!(
+            format_transaction(
+                &make_tx(TransactionType::ProviderRegistration),
+                1000,
+                "DASH"
+            )
+            .type_badge,
+            Some("ProReg")
+        );
+        assert_eq!(
+            format_transaction(&make_tx(TransactionType::Ignored), 1000, "DASH").type_badge,
+            None
+        );
     }
 
     // -- parse_dash_amount --

--- a/src/state/view_models.rs
+++ b/src/state/view_models.rs
@@ -214,6 +214,14 @@ pub fn matches_search(tx: &TransactionInfo, query: &str, unit: &str) -> bool {
             .is_some_and(|l| l.to_lowercase().contains(&q))
 }
 
+struct DirectionStyle {
+    label: &'static str,
+    icon: &'static str,
+    icon_class: &'static str,
+    border_class: &'static str,
+    amount_class: &'static str,
+}
+
 /// Display-ready transaction info.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TransactionView {
@@ -266,37 +274,36 @@ pub fn format_transaction(
 ) -> TransactionView {
     let txid_hex = tx.txid.to_string();
 
-    let (direction_label, direction_icon, direction_icon_class, border_class, amount_class) =
-        match tx.direction {
-            TransactionDirection::Incoming => (
-                "Received",
-                "\u{25bc}",
-                "text-success text-lg flex-shrink-0",
-                "border-success",
-                "text-success font-medium",
-            ),
-            TransactionDirection::Outgoing => (
-                "Sent",
-                "\u{25b2}",
-                "text-error text-lg flex-shrink-0",
-                "border-error",
-                "text-error font-medium",
-            ),
-            TransactionDirection::Internal => (
-                "Internal",
-                "\u{21c4}",
-                "text-muted text-lg flex-shrink-0",
-                "border-muted",
-                "text-muted font-medium",
-            ),
-            TransactionDirection::CoinJoin => (
-                "CoinJoin",
-                "\u{21cb}",
-                "text-muted text-lg flex-shrink-0",
-                "border-muted",
-                "text-muted font-medium",
-            ),
-        };
+    let style = match tx.direction {
+        TransactionDirection::Incoming => DirectionStyle {
+            label: "Received",
+            icon: "\u{25bc}",
+            icon_class: "text-success text-lg flex-shrink-0",
+            border_class: "border-success",
+            amount_class: "text-success font-medium",
+        },
+        TransactionDirection::Outgoing => DirectionStyle {
+            label: "Sent",
+            icon: "\u{25b2}",
+            icon_class: "text-error text-lg flex-shrink-0",
+            border_class: "border-error",
+            amount_class: "text-error font-medium",
+        },
+        TransactionDirection::Internal => DirectionStyle {
+            label: "Internal",
+            icon: "\u{21c4}",
+            icon_class: "text-muted text-lg flex-shrink-0",
+            border_class: "border-muted",
+            amount_class: "text-muted font-medium",
+        },
+        TransactionDirection::CoinJoin => DirectionStyle {
+            label: "CoinJoin",
+            icon: "\u{21cb}",
+            icon_class: "text-muted text-lg flex-shrink-0",
+            border_class: "border-muted",
+            amount_class: "text-muted font-medium",
+        },
+    };
 
     let type_badge = type_badge_label(tx.transaction_type, tx.direction);
 
@@ -315,11 +322,11 @@ pub fn format_transaction(
 
     TransactionView {
         txid_hex,
-        direction_label,
-        direction_icon,
-        direction_icon_class,
-        border_class,
-        amount_class,
+        direction_label: style.label,
+        direction_icon: style.icon,
+        direction_icon_class: style.icon_class,
+        border_class: style.border_class,
+        amount_class: style.amount_class,
         type_badge,
         amount_display,
         timestamp_display,


### PR DESCRIPTION
## Summary

- Extract direction-dependent CSS classes and icons into `TransactionView` fields in the view model layer
- Add `type_badge` field for non-standard transaction types (CoinJoin, Coinbase, AssetLock, etc.)
- Replace all inline `match tx.direction` arms in `dashboard.rs` and `transactions.rs` with pre-computed view model fields
- Extract reusable `TransactionRow` component in transactions screen

Closes #141