### PR TITLE
feat: add transaction labels

### DIFF
--- a/src/backend/dispatch.rs
+++ b/src/backend/dispatch.rs
@@ -144,6 +144,15 @@ impl SpvBackend for Backend {
         }
     }
 
+    async fn set_transaction_label(&self, txid: &str, label: &str) -> BackendResult<()> {
+        match self {
+            Self::Native(b) => b.set_transaction_label(txid, label).await,
+            Self::Mock(b) => b.set_transaction_label(txid, label).await,
+            #[cfg(feature = "ffi")]
+            Self::Ffi(b) => b.set_transaction_label(txid, label).await,
+        }
+    }
+
     fn cache_size(&self) -> BackendResult<u64> {
         match self {
             Self::Native(b) => b.cache_size(),
@@ -400,6 +409,22 @@ mod tests {
         // Verify the mnemonic can be used to create a wallet through dispatch
         backend.create_wallet(&mnemonic).await.unwrap();
         assert!(backend.get_balance().is_ok());
+    }
+
+    #[tokio::test]
+    async fn dispatch_set_transaction_label() {
+        let backend = mock_backend_with_wallet(Network::Testnet, 1_000_000);
+        backend.load_wallet().await.unwrap();
+        backend.send("Xaddr", 100_000, 1000).await.unwrap();
+
+        let txid = backend.get_transactions().unwrap()[0].txid.to_string();
+        backend
+            .set_transaction_label(&txid, "test label")
+            .await
+            .unwrap();
+
+        let tx = &backend.get_transactions().unwrap()[0];
+        assert_eq!(tx.label, Some("test label".into()));
     }
 
     #[tokio::test]

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -44,7 +44,8 @@ use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoIn
 use key_wallet_ffi::error::FFIError as WalletFFIError;
 use key_wallet_ffi::managed_account::{
     FFITransactionRecord, managed_core_account_free, managed_core_account_free_transactions,
-    managed_core_account_get_transactions, managed_wallet_get_account,
+    managed_core_account_get_transactions, managed_core_account_set_transaction_label,
+    managed_wallet_get_account,
 };
 use key_wallet_ffi::managed_wallet::{
     managed_wallet_get_next_bip44_change_address, managed_wallet_info_free,
@@ -655,6 +656,100 @@ impl SpvBackend for FfiBackend {
             });
 
             Ok(transactions)
+        })
+        .join()
+        .map_err(|_| BackendError::Internal("FFI thread panicked".into()))?
+    }
+
+    async fn set_transaction_label(&self, txid: &str, label: &str) -> BackendResult<()> {
+        let client_usize = self.require_client()?;
+        let txid_parsed = dashcore::Txid::from_str(txid)
+            .map_err(|e| BackendError::Internal(format!("invalid txid: {e}")))?;
+        let txid_bytes = txid_parsed.to_byte_array();
+        let label = label.to_owned();
+
+        std::thread::spawn(move || {
+            let client_ptr = client_usize as *mut FFIDashSpvClient;
+
+            // Safety: client_ptr was cast from a valid pointer.
+            let wm = unsafe { dash_spv_ffi_client_get_wallet_manager(client_ptr) };
+            if wm.is_null() {
+                return Err(BackendError::Internal(get_last_ffi_error()));
+            }
+            let wm_typed = wm as *const key_wallet_ffi::FFIWalletManager;
+
+            let mut wallet_ids_ptr: *mut u8 = std::ptr::null_mut();
+            let mut count: usize = 0;
+            let mut error = WalletFFIError::success();
+
+            let ok = unsafe {
+                wallet_manager_get_wallet_ids(wm_typed, &mut wallet_ids_ptr, &mut count, &mut error)
+            };
+
+            if !ok || count == 0 {
+                unsafe { dash_spv_ffi_wallet_manager_free(wm) };
+                return Err(BackendError::NoWallet);
+            }
+
+            let mut wallet_id = [0u8; 32];
+            unsafe {
+                std::ptr::copy_nonoverlapping(wallet_ids_ptr, wallet_id.as_mut_ptr(), 32);
+                wallet_manager_free_wallet_ids(wallet_ids_ptr, count);
+            }
+
+            let account_result = unsafe {
+                managed_wallet_get_account(
+                    wm_typed,
+                    wallet_id.as_ptr(),
+                    FFIAccountType::Bip44Standard,
+                    0,
+                    &mut error,
+                )
+            };
+
+            if account_result.account.is_null() {
+                unsafe { dash_spv_ffi_wallet_manager_free(wm) };
+                return Err(BackendError::Internal(format!(
+                    "failed to get account: {}",
+                    error.message_string()
+                )));
+            }
+
+            let account_ptr = account_result.account;
+
+            let label_c = if label.is_empty() {
+                None
+            } else {
+                Some(
+                    CString::new(label.as_bytes())
+                        .map_err(|e| BackendError::Internal(format!("invalid label: {e}")))?,
+                )
+            };
+            let label_ptr = label_c.as_ref().map_or(std::ptr::null(), |c| c.as_ptr());
+
+            // Safety: account_ptr and txid_bytes are valid.
+            let ok = unsafe {
+                managed_core_account_set_transaction_label(
+                    account_ptr,
+                    txid_bytes.as_ptr(),
+                    label_ptr,
+                    &mut error,
+                )
+            };
+
+            unsafe {
+                managed_core_account_free(account_ptr);
+                dash_spv_ffi_wallet_manager_free(wm);
+            }
+
+            if !ok {
+                return Err(BackendError::Internal(format!(
+                    "failed to set label: {}",
+                    error.message_string()
+                )));
+            }
+
+            Ok(())
         })
         .join()
         .map_err(|_| BackendError::Internal("FFI thread panicked".into()))?

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use std::sync::{
     Mutex,
     atomic::{AtomicBool, AtomicU32, Ordering},
@@ -249,6 +250,33 @@ impl SpvBackend for MockBackend {
         self.emit(SpvEvent::TransactionReceived(Box::new(record)));
 
         Ok(txid_bytes)
+    }
+
+    async fn set_transaction_label(&self, txid: &str, label: &str) -> BackendResult<()> {
+        self.require_wallet()?;
+
+        let txid = dashcore::Txid::from_str(txid)
+            .map_err(|e| BackendError::Internal(format!("invalid txid: {e}")))?;
+
+        if !label.is_empty() && label.len() > 256 {
+            return Err(BackendError::Internal(
+                "Label exceeds 256 bytes".to_string(),
+            ));
+        }
+
+        let mut transactions = self.transactions.lock().unwrap();
+        let tx = transactions
+            .iter_mut()
+            .find(|t| t.txid == txid)
+            .ok_or_else(|| BackendError::Internal("transaction not found".to_string()))?;
+
+        tx.label = if label.is_empty() {
+            None
+        } else {
+            Some(label.to_owned())
+        };
+
+        Ok(())
     }
 
     fn cache_size(&self) -> BackendResult<u64> {
@@ -625,5 +653,106 @@ mod tests {
     async fn clear_cache_is_noop() {
         let backend = MockBackend::builder(Network::Testnet).build();
         backend.clear_cache().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn set_transaction_label_success() {
+        let txs = vec![mock_transaction(0, TransactionDirection::Incoming, 100_000)];
+        let backend = MockBackend::builder(Network::Testnet)
+            .with_transactions(txs)
+            .build();
+        backend.create_wallet(TEST_MNEMONIC_12).await.unwrap();
+
+        let txid = backend.get_transactions().unwrap()[0].txid.to_string();
+
+        backend
+            .set_transaction_label(&txid, "coffee payment")
+            .await
+            .unwrap();
+
+        let tx = &backend.get_transactions().unwrap()[0];
+        assert_eq!(tx.label, Some("coffee payment".into()));
+    }
+
+    #[tokio::test]
+    async fn set_transaction_label_clear() {
+        let mut tx = mock_transaction(0, TransactionDirection::Incoming, 100_000);
+        tx.label = Some("old label".into());
+        let backend = MockBackend::builder(Network::Testnet)
+            .with_transactions(vec![tx])
+            .build();
+        backend.create_wallet(TEST_MNEMONIC_12).await.unwrap();
+
+        let txid = backend.get_transactions().unwrap()[0].txid.to_string();
+
+        backend.set_transaction_label(&txid, "").await.unwrap();
+
+        let tx = &backend.get_transactions().unwrap()[0];
+        assert_eq!(tx.label, None);
+    }
+
+    #[tokio::test]
+    async fn set_transaction_label_too_long() {
+        let txs = vec![mock_transaction(0, TransactionDirection::Incoming, 100_000)];
+        let backend = MockBackend::builder(Network::Testnet)
+            .with_transactions(txs)
+            .build();
+        backend.create_wallet(TEST_MNEMONIC_12).await.unwrap();
+
+        let txid = backend.get_transactions().unwrap()[0].txid.to_string();
+        let long_label = "x".repeat(257);
+
+        let err = backend
+            .set_transaction_label(&txid, &long_label)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BackendError::Internal(_)));
+    }
+
+    #[tokio::test]
+    async fn set_transaction_label_not_found() {
+        let backend = MockBackend::builder(Network::Testnet).build();
+        backend.create_wallet(TEST_MNEMONIC_12).await.unwrap();
+
+        let fake_txid = "0000000000000000000000000000000000000000000000000000000000000001";
+        let err = backend
+            .set_transaction_label(fake_txid, "label")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BackendError::Internal(_)));
+    }
+
+    #[tokio::test]
+    async fn set_transaction_label_no_wallet() {
+        let backend = MockBackend::builder(Network::Testnet).build();
+
+        let err = backend
+            .set_transaction_label(
+                "0000000000000000000000000000000000000000000000000000000000000001",
+                "label",
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err, BackendError::NoWallet);
+    }
+
+    #[tokio::test]
+    async fn set_transaction_label_max_length() {
+        let txs = vec![mock_transaction(0, TransactionDirection::Incoming, 100_000)];
+        let backend = MockBackend::builder(Network::Testnet)
+            .with_transactions(txs)
+            .build();
+        backend.create_wallet(TEST_MNEMONIC_12).await.unwrap();
+
+        let txid = backend.get_transactions().unwrap()[0].txid.to_string();
+        let max_label = "x".repeat(256);
+
+        backend
+            .set_transaction_label(&txid, &max_label)
+            .await
+            .unwrap();
+
+        let tx = &backend.get_transactions().unwrap()[0];
+        assert_eq!(tx.label, Some(max_label));
     }
 }

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -383,6 +383,29 @@ impl SpvBackend for NativeBackend {
         Ok(transactions)
     }
 
+    async fn set_transaction_label(&self, txid: &str, label: &str) -> BackendResult<()> {
+        let txid = dashcore::Txid::from_str(txid)
+            .map_err(|e| BackendError::Internal(format!("invalid txid: {e}")))?;
+
+        let mut wallet = self.wallet.write().await;
+        let wallet_ids: Vec<_> = wallet.list_wallets().into_iter().cloned().collect();
+        let wallet_id = wallet_ids.first().ok_or(BackendError::NoWallet)?;
+
+        let wallet_info = wallet
+            .get_wallet_info_mut(wallet_id)
+            .ok_or(BackendError::NoWallet)?;
+
+        for account in wallet_info.accounts_mut().all_accounts_mut() {
+            if let Some(record) = account.transactions.get_mut(&txid) {
+                return record
+                    .set_label(label.to_owned())
+                    .map_err(|e| BackendError::Internal(e.to_string()));
+            }
+        }
+
+        Err(BackendError::Internal("transaction not found".to_string()))
+    }
+
     fn estimate_fee(&self, _address: &str, _amount: u64, fee_rate: u32) -> BackendResult<u64> {
         // Estimate for a typical 1-input 2-output P2PKH transaction (226 bytes)
         let fee = FeeRate::new(fee_rate as u64).calculate_fee(226);

--- a/src/backend/trait.rs
+++ b/src/backend/trait.rs
@@ -60,6 +60,17 @@ pub trait SpvBackend: Send + Sync + 'static {
         fee_rate: u32,
     ) -> impl Future<Output = BackendResult<[u8; 32]>> + Send;
 
+    // -- Labels --
+
+    /// Set or clear a label on a transaction.
+    ///
+    /// An empty string clears the label. The label must not exceed 256 bytes.
+    fn set_transaction_label(
+        &self,
+        txid: &str,
+        label: &str,
+    ) -> impl Future<Output = BackendResult<()>> + Send;
+
     // -- Cache --
 
     /// Returns the total size in bytes of cached SPV data (headers, filters, blocks, etc.).

--- a/src/screens/dashboard.rs
+++ b/src/screens/dashboard.rs
@@ -118,6 +118,9 @@ pub fn Dashboard() -> Element {
                                                 }
                                                 div { class: "min-w-0",
                                                     p { class: "font-mono text-sm truncate", "{address_short}" }
+                                                    if let Some(label) = &view.label {
+                                                        p { class: "text-muted text-xs truncate", "{label}" }
+                                                    }
                                                     p { class: "text-disabled text-xs", "{view.timestamp_display}" }
                                                 }
                                             }
@@ -153,6 +156,13 @@ pub fn Dashboard() -> Element {
                                                 div { class: "flex justify-between",
                                                     span { class: "text-muted", "Transaction ID" }
                                                     span { class: "font-mono text-xs select-all", "{tx.txid}" }
+                                                }
+
+                                                if let Some(label) = &tx.label {
+                                                    div { class: "flex justify-between",
+                                                        span { class: "text-muted", "Label" }
+                                                        span { "{label}" }
+                                                    }
                                                 }
 
                                                 if let Some(hash) = &tx.block_hash {

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -192,6 +192,9 @@ pub fn Transactions() -> Element {
                                             }
                                             div { class: "min-w-0",
                                                 p { class: "font-mono text-sm truncate", "{address_short}" }
+                                                if let Some(label) = &view.label {
+                                                    p { class: "text-muted text-xs truncate", "{label}" }
+                                                }
                                                 p { class: "text-disabled text-xs", "{view.timestamp_display}" }
                                             }
                                         }
@@ -239,6 +242,13 @@ pub fn Transactions() -> Element {
                                             div { class: "flex justify-between",
                                                 span { class: "text-muted", "Transaction ID" }
                                                 span { class: "font-mono text-xs select-all", "{tx.txid}" }
+                                            }
+
+                                            if let Some(label) = &tx.label {
+                                                div { class: "flex justify-between",
+                                                    span { class: "text-muted", "Label" }
+                                                    span { "{label}" }
+                                                }
                                             }
 
                                             if let Some(hash) = &tx.block_hash {

--- a/src/state/view_models.rs
+++ b/src/state/view_models.rs
@@ -225,6 +225,7 @@ pub struct TransactionView {
     pub address_short: String,
     pub is_instant_send: bool,
     pub is_chain_locked: bool,
+    pub label: Option<String>,
 }
 
 /// Convert a transaction record to a display-ready view.
@@ -263,6 +264,7 @@ pub fn format_transaction(
         address_short,
         is_instant_send: tx.is_instant_send,
         is_chain_locked: tx.is_chain_locked,
+        label: tx.label.clone(),
     }
 }
 
@@ -534,6 +536,48 @@ mod tests {
 
         let view = format_transaction(&tx, 0, "DASH");
         assert_eq!(view.address_short, "");
+    }
+
+    #[test]
+    fn format_transaction_with_label() {
+        let tx = TransactionInfo {
+            txid: dashcore::Txid::from_byte_array([0xEE; 32]),
+            amount: 50_000_000,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
+            timestamp: 1700000000,
+            height: Some(500),
+            fee: None,
+            addresses: vec!["Xaddr".into()],
+            block_hash: None,
+            is_instant_send: false,
+            is_chain_locked: false,
+            label: Some("coffee payment".into()),
+        };
+
+        let view = format_transaction(&tx, 1000, "DASH");
+        assert_eq!(view.label, Some("coffee payment".into()));
+    }
+
+    #[test]
+    fn format_transaction_without_label() {
+        let tx = TransactionInfo {
+            txid: dashcore::Txid::from_byte_array([0xFF; 32]),
+            amount: 50_000_000,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
+            timestamp: 1700000000,
+            height: Some(500),
+            fee: None,
+            addresses: vec!["Xaddr".into()],
+            block_hash: None,
+            is_instant_send: false,
+            is_chain_locked: false,
+            label: None,
+        };
+
+        let view = format_transaction(&tx, 1000, "DASH");
+        assert_eq!(view.label, None);
     }
 
     // -- parse_dash_amount --

--- a/src/state/wallet.rs
+++ b/src/state/wallet.rs
@@ -61,6 +61,13 @@ impl WalletState {
         }
     }
 
+    /// Update the label on a transaction in the local state.
+    pub fn set_transaction_label(&mut self, txid: &dashcore::Txid, label: Option<String>) {
+        if let Some(tx) = self.transactions.iter_mut().find(|t| t.txid == *txid) {
+            tx.label = label;
+        }
+    }
+
     /// Replace the full transaction list (e.g., after initial load).
     pub fn set_transactions(&mut self, mut transactions: Vec<TransactionInfo>) {
         sort_transactions(&mut transactions);
@@ -547,5 +554,35 @@ mod tests {
             state.transactions[0].label,
             Some("payment for coffee".into())
         );
+    }
+
+    #[test]
+    fn set_transaction_label_updates_existing() {
+        let mut state = WalletState::default();
+        let txid = dashcore::Txid::from_byte_array([9u8; 32]);
+
+        state.apply_event(&tx_event(
+            9,
+            100_000,
+            TransactionDirection::Incoming,
+            vec!["Xaddr9".into()],
+            Some(500),
+            1700000000,
+        ));
+
+        state.set_transaction_label(&txid, Some("rent payment".into()));
+        assert_eq!(state.transactions[0].label, Some("rent payment".into()));
+
+        state.set_transaction_label(&txid, None);
+        assert_eq!(state.transactions[0].label, None);
+    }
+
+    #[test]
+    fn set_transaction_label_nonexistent_is_noop() {
+        let mut state = WalletState::default();
+        let txid = dashcore::Txid::from_byte_array([99u8; 32]);
+
+        state.set_transaction_label(&txid, Some("label".into()));
+        assert!(state.transactions.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Add `set_transaction_label` to `SpvBackend` trait with implementations for Native, FFI, and Mock backends
- Add label display in transaction list rows and expanded detail view
- Add `WalletState::set_transaction_label` for UI-side state updates
- Validate max 256 bytes, empty string clears label

**Draft** — will rebase after #154 merges.

Closes #142