### PR TITLE
feat: add input/output breakdown to expanded transaction details

### DIFF
--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1663,7 +1663,7 @@ fn extract_ffi_input_addresses(record: &FFITransactionRecord) -> Vec<String> {
     addrs
 }
 
-const MAX_DETAIL_COUNT: usize = 1_000_000;
+const MAX_DETAIL_COUNT: usize = 10_000;
 
 /// Extract `InputInfo` entries from an `FFITransactionRecord`.
 fn extract_ffi_inputs(record: &FFITransactionRecord) -> Vec<InputInfo> {

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1663,9 +1663,19 @@ fn extract_ffi_input_addresses(record: &FFITransactionRecord) -> Vec<String> {
     addrs
 }
 
+const MAX_DETAIL_COUNT: usize = 1_000_000;
+
 /// Extract `InputInfo` entries from an `FFITransactionRecord`.
 fn extract_ffi_inputs(record: &FFITransactionRecord) -> Vec<InputInfo> {
     if record.input_details.is_null() || record.input_details_count == 0 {
+        return Vec::new();
+    }
+    if record.input_details_count > MAX_DETAIL_COUNT {
+        tracing::warn!(
+            count = record.input_details_count,
+            max = MAX_DETAIL_COUNT,
+            "FFI input_details_count exceeds safety bound, ignoring"
+        );
         return Vec::new();
     }
     // Safety: input_details is a valid pointer to an array of input_details_count elements.
@@ -1698,6 +1708,14 @@ fn extract_ffi_inputs(record: &FFITransactionRecord) -> Vec<InputInfo> {
 /// record.
 fn extract_ffi_outputs(record: &FFITransactionRecord, network: Network) -> Vec<OutputInfo> {
     if record.output_details.is_null() || record.output_details_count == 0 {
+        return Vec::new();
+    }
+    if record.output_details_count > MAX_DETAIL_COUNT {
+        tracing::warn!(
+            count = record.output_details_count,
+            max = MAX_DETAIL_COUNT,
+            "FFI output_details_count exceeds safety bound, ignoring"
+        );
         return Vec::new();
     }
     // Safety: output_details is a valid pointer to an array of output_details_count elements.
@@ -1767,6 +1785,9 @@ mod tests {
     use std::ffi::CString;
     use std::ptr;
 
+    use dashcore::consensus::serialize;
+    use dashcore::key::PublicKey;
+    use dashcore::{Address, Transaction};
     use key_wallet_ffi::types::{
         FFIBlockInfo, FFIInputDetail, FFIOutputDetail, FFITransactionContext,
         FFITransactionContextType, FFITransactionDirection, FFITransactionType,
@@ -1883,6 +1904,45 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].value, 0);
         assert_eq!(result[0].address, "");
+    }
+
+    #[test]
+    fn extract_ffi_outputs_valid_tx_extracts_value_and_address() {
+        let pk = PublicKey::from_slice(&[
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x01,
+        ])
+        .unwrap();
+        let addr = Address::p2pkh(&pk, dashcore::Network::Testnet);
+        let tx = Transaction::dummy(&addr, 0..1, &[99_774, 226]);
+        let tx_bytes = serialize(&tx);
+
+        let mut details = [
+            FFIOutputDetail {
+                index: 0,
+                role: FFIOutputRole::Received,
+            },
+            FFIOutputDetail {
+                index: 1,
+                role: FFIOutputRole::Change,
+            },
+        ];
+        let mut record = empty_record();
+        record.output_details = details.as_mut_ptr();
+        record.output_details_count = details.len();
+        record.tx_data = tx_bytes.as_ptr() as *mut _;
+        record.tx_len = tx_bytes.len();
+
+        let result = extract_ffi_outputs(&record, Network::Testnet);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].index, 0);
+        assert_eq!(result[0].value, 99_774);
+        assert_eq!(result[0].address, addr.to_string());
+        assert_eq!(result[0].role, OutputRole::Received);
+        assert_eq!(result[1].index, 1);
+        assert_eq!(result[1].value, 226);
+        assert_eq!(result[1].role, OutputRole::Change);
     }
 
     #[test]

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -51,7 +51,7 @@ use key_wallet_ffi::managed_wallet::{
 };
 use key_wallet_ffi::mnemonic::{mnemonic_free, mnemonic_generate};
 use key_wallet_ffi::types::{
-    FFIAccountType, FFINetwork, FFITransactionContextType, FFITransactionDirection,
+    FFIAccountType, FFINetwork, FFIOutputRole, FFITransactionContextType, FFITransactionDirection,
     FFITransactionType,
 };
 use key_wallet_ffi::utxo::{managed_wallet_get_utxos, utxo_array_free};
@@ -67,8 +67,8 @@ use super::error::{BackendError, BackendResult};
 use super::events::{EventReceiver, EventSender, SpvEvent, event_channel};
 use super::r#trait::SpvBackend;
 use super::types::{
-    Network, SyncProgress, TransactionDirection, TransactionInfo, TransactionType,
-    WalletCoreBalance,
+    InputInfo, Network, OutputInfo, OutputRole, SyncProgress, TransactionDirection,
+    TransactionInfo, TransactionType, WalletCoreBalance,
 };
 use crate::config::AppConfig;
 
@@ -609,6 +609,9 @@ impl SpvBackend for FfiBackend {
                     // Safety: label is a valid C string for the lifetime of the record.
                     let label = unsafe { extract_ffi_label(record.label) };
 
+                    let inputs = extract_ffi_inputs(record);
+                    let outputs = extract_ffi_outputs(record);
+
                     transactions.push(TransactionInfo {
                         txid,
                         amount: record.net_amount,
@@ -634,6 +637,8 @@ impl SpvBackend for FfiBackend {
                         is_instant_send,
                         is_chain_locked,
                         label,
+                        inputs,
+                        outputs,
                     });
                 }
 
@@ -1477,6 +1482,8 @@ extern "C" fn on_transaction_received(
     let has_block = block_info.block_hash != [0u8; 32] && block_info.timestamp != 0;
 
     let addresses = extract_ffi_input_addresses(r);
+    let inputs = extract_ffi_inputs(r);
+    let outputs = extract_ffi_outputs(r);
 
     // Safety: label is a valid C string for the duration of the callback.
     let label = unsafe { extract_ffi_label(r.label) };
@@ -1513,6 +1520,8 @@ extern "C" fn on_transaction_received(
             is_instant_send,
             is_chain_locked,
             label,
+            inputs,
+            outputs,
         })));
 }
 
@@ -1646,6 +1655,92 @@ fn extract_ffi_input_addresses(record: &FFITransactionRecord) -> Vec<String> {
     addrs.sort();
     addrs.dedup();
     addrs
+}
+
+/// Extract `InputInfo` entries from an `FFITransactionRecord`.
+fn extract_ffi_inputs(record: &FFITransactionRecord) -> Vec<InputInfo> {
+    if record.input_details.is_null() || record.input_details_count == 0 {
+        return Vec::new();
+    }
+    // Safety: input_details is a valid pointer to an array of input_details_count elements.
+    let details =
+        unsafe { std::slice::from_raw_parts(record.input_details, record.input_details_count) };
+    details
+        .iter()
+        .map(|d| {
+            let address = if d.address.is_null() {
+                String::new()
+            } else {
+                // Safety: address is a valid C string for the duration of the callback.
+                unsafe { CStr::from_ptr(d.address) }
+                    .to_string_lossy()
+                    .into_owned()
+            };
+            InputInfo {
+                index: d.index,
+                value: d.value,
+                address,
+            }
+        })
+        .collect()
+}
+
+/// Extract `OutputInfo` entries from an `FFITransactionRecord`.
+///
+/// The FFI `OutputDetail` only carries index and role. Value and address are
+/// extracted from the consensus-serialized transaction bytes embedded in the
+/// record.
+fn extract_ffi_outputs(record: &FFITransactionRecord) -> Vec<OutputInfo> {
+    if record.output_details.is_null() || record.output_details_count == 0 {
+        return Vec::new();
+    }
+    // Safety: output_details is a valid pointer to an array of output_details_count elements.
+    let details =
+        unsafe { std::slice::from_raw_parts(record.output_details, record.output_details_count) };
+
+    // Attempt to deserialize the raw transaction so we can read output values/addresses.
+    let tx: Option<dashcore::blockdata::transaction::Transaction> =
+        if !record.tx_data.is_null() && record.tx_len > 0 {
+            // Safety: tx_data is a valid pointer for tx_len bytes.
+            let bytes = unsafe { std::slice::from_raw_parts(record.tx_data, record.tx_len) };
+            dashcore::consensus::deserialize(bytes).ok()
+        } else {
+            None
+        };
+
+    details
+        .iter()
+        .map(|d| {
+            let (value, address) = tx
+                .as_ref()
+                .and_then(|t| t.output.get(d.index as usize))
+                .map(|o| {
+                    let addr = dashcore::Address::from_script(
+                        &o.script_pubkey,
+                        dashcore::Network::Mainnet,
+                    )
+                    .ok()
+                    .map_or_else(String::new, |a| a.to_string());
+                    (o.value, addr)
+                })
+                .unwrap_or((0, String::new()));
+            OutputInfo {
+                index: d.index,
+                value,
+                address,
+                role: ffi_output_role_to_role(d.role),
+            }
+        })
+        .collect()
+}
+
+fn ffi_output_role_to_role(role: FFIOutputRole) -> OutputRole {
+    match role {
+        FFIOutputRole::Received => OutputRole::Received,
+        FFIOutputRole::Change => OutputRole::Change,
+        FFIOutputRole::Sent => OutputRole::Sent,
+        FFIOutputRole::Unspendable => OutputRole::Unspendable,
+    }
 }
 
 #[cfg(test)]

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -76,6 +76,7 @@ use crate::config::AppConfig;
 struct CallbackContext {
     event_tx: EventSender,
     progress: std::sync::Arc<RwLock<SyncProgress>>,
+    network: Network,
 }
 
 pub struct FfiBackend {
@@ -205,7 +206,11 @@ impl SpvBackend for FfiBackend {
                 };
             }
 
-            let ctx = Box::new(CallbackContext { event_tx, progress });
+            let ctx = Box::new(CallbackContext {
+                event_tx,
+                progress,
+                network: app_network,
+            });
             let user_data = Box::into_raw(ctx) as *mut c_void;
 
             let callbacks = FFIEventCallbacks {
@@ -514,6 +519,7 @@ impl SpvBackend for FfiBackend {
             return Err(BackendError::NotRunning);
         }
 
+        let network = self.config.network;
         std::thread::spawn(move || {
             let client_ptr = client_usize as *mut FFIDashSpvClient;
 
@@ -610,7 +616,7 @@ impl SpvBackend for FfiBackend {
                     let label = unsafe { extract_ffi_label(record.label) };
 
                     let inputs = extract_ffi_inputs(record);
-                    let outputs = extract_ffi_outputs(record);
+                    let outputs = extract_ffi_outputs(record, network);
 
                     transactions.push(TransactionInfo {
                         txid,
@@ -1483,7 +1489,7 @@ extern "C" fn on_transaction_received(
 
     let addresses = extract_ffi_input_addresses(r);
     let inputs = extract_ffi_inputs(r);
-    let outputs = extract_ffi_outputs(r);
+    let outputs = extract_ffi_outputs(r, ctx.network);
 
     // Safety: label is a valid C string for the duration of the callback.
     let label = unsafe { extract_ffi_label(r.label) };
@@ -1690,7 +1696,7 @@ fn extract_ffi_inputs(record: &FFITransactionRecord) -> Vec<InputInfo> {
 /// The FFI `OutputDetail` only carries index and role. Value and address are
 /// extracted from the consensus-serialized transaction bytes embedded in the
 /// record.
-fn extract_ffi_outputs(record: &FFITransactionRecord) -> Vec<OutputInfo> {
+fn extract_ffi_outputs(record: &FFITransactionRecord, network: Network) -> Vec<OutputInfo> {
     if record.output_details.is_null() || record.output_details_count == 0 {
         return Vec::new();
     }
@@ -1715,12 +1721,9 @@ fn extract_ffi_outputs(record: &FFITransactionRecord) -> Vec<OutputInfo> {
                 .as_ref()
                 .and_then(|t| t.output.get(d.index as usize))
                 .map(|o| {
-                    let addr = dashcore::Address::from_script(
-                        &o.script_pubkey,
-                        dashcore::Network::Mainnet,
-                    )
-                    .ok()
-                    .map_or_else(String::new, |a| a.to_string());
+                    let addr = dashcore::Address::from_script(&o.script_pubkey, network)
+                        .ok()
+                        .map_or_else(String::new, |a| a.to_string());
                     (o.value, addr)
                 })
                 .unwrap_or((0, String::new()));

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1861,6 +1861,21 @@ mod tests {
     }
 
     #[test]
+    fn extract_ffi_inputs_oversized_count_skips_extraction() {
+        let mut detail = FFIInputDetail {
+            index: 0,
+            value: 0,
+            address: ptr::null_mut(),
+        };
+        let mut record = empty_record();
+        record.input_details = &mut detail as *mut _;
+        record.input_details_count = MAX_DETAIL_COUNT + 1;
+
+        let result = extract_ffi_inputs(&record);
+        assert!(result.is_empty());
+    }
+
+    #[test]
     fn extract_ffi_outputs_null_pointer_returns_empty() {
         let record = empty_record();
         let result = extract_ffi_outputs(&record, Network::Mainnet);

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1876,6 +1876,20 @@ mod tests {
     }
 
     #[test]
+    fn extract_ffi_outputs_oversized_count_skips_extraction() {
+        let mut detail = FFIOutputDetail {
+            index: 0,
+            role: FFIOutputRole::Received,
+        };
+        let mut record = empty_record();
+        record.output_details = &mut detail as *mut _;
+        record.output_details_count = MAX_DETAIL_COUNT + 1;
+
+        let result = extract_ffi_outputs(&record, Network::Mainnet);
+        assert!(result.is_empty());
+    }
+
+    #[test]
     fn extract_ffi_outputs_null_pointer_returns_empty() {
         let record = empty_record();
         let result = extract_ffi_outputs(&record, Network::Mainnet);

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1711,7 +1711,9 @@ fn extract_ffi_outputs(record: &FFITransactionRecord, network: Network) -> Vec<O
             let bytes = unsafe { std::slice::from_raw_parts(record.tx_data, record.tx_len) };
             let result = dashcore::consensus::deserialize(bytes);
             if result.is_err() {
-                tracing::warn!("FFI: failed to deserialize tx_data; output values/addresses will be empty");
+                tracing::warn!(
+                    "FFI: failed to deserialize tx_data; output values/addresses will be empty"
+                );
             }
             result.ok()
         } else {

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1709,7 +1709,11 @@ fn extract_ffi_outputs(record: &FFITransactionRecord, network: Network) -> Vec<O
         if !record.tx_data.is_null() && record.tx_len > 0 {
             // Safety: tx_data is a valid pointer for tx_len bytes.
             let bytes = unsafe { std::slice::from_raw_parts(record.tx_data, record.tx_len) };
-            dashcore::consensus::deserialize(bytes).ok()
+            let result = dashcore::consensus::deserialize(bytes);
+            if result.is_err() {
+                tracing::warn!("FFI: failed to deserialize tx_data; output values/addresses will be empty");
+            }
+            result.ok()
         } else {
             None
         };

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1707,15 +1707,24 @@ fn extract_ffi_outputs(record: &FFITransactionRecord, network: Network) -> Vec<O
     // Attempt to deserialize the raw transaction so we can read output values/addresses.
     let tx: Option<dashcore::blockdata::transaction::Transaction> =
         if !record.tx_data.is_null() && record.tx_len > 0 {
-            // Safety: tx_data is a valid pointer for tx_len bytes.
-            let bytes = unsafe { std::slice::from_raw_parts(record.tx_data, record.tx_len) };
-            let result = dashcore::consensus::deserialize(bytes);
-            if result.is_err() {
+            if record.tx_len > 1_048_576 {
                 tracing::warn!(
-                    "FFI: failed to deserialize tx_data; output values/addresses will be empty"
+                    "FFI: tx_len {} exceeds maximum; skipping output enrichment",
+                    record.tx_len
                 );
+                None
+            } else {
+                // Safety: tx_data is a valid pointer for tx_len bytes.
+                let bytes =
+                    unsafe { std::slice::from_raw_parts(record.tx_data, record.tx_len) };
+                let result = dashcore::consensus::deserialize(bytes);
+                if result.is_err() {
+                    tracing::warn!(
+                        "FFI: failed to deserialize tx_data; output values/addresses will be empty"
+                    );
+                }
+                result.ok()
             }
-            result.ok()
         } else {
             None
         };
@@ -1723,9 +1732,11 @@ fn extract_ffi_outputs(record: &FFITransactionRecord, network: Network) -> Vec<O
     details
         .iter()
         .map(|d| {
-            let (value, address) = tx
-                .as_ref()
-                .and_then(|t| t.output.get(d.index as usize))
+            let out = tx.as_ref().and_then(|t| t.output.get(d.index as usize));
+            if out.is_none() && tx.is_some() {
+                tracing::warn!("FFI: output index {} out of bounds", d.index);
+            }
+            let (value, address) = out
                 .map(|o| {
                     let addr = dashcore::Address::from_script(&o.script_pubkey, network)
                         .ok()
@@ -1757,9 +1768,123 @@ mod tests {
     use std::ffi::CString;
     use std::ptr;
 
-    use key_wallet_ffi::types::{FFITransactionDirection, FFITransactionType};
+    use key_wallet_ffi::types::{
+        FFIBlockInfo, FFIInputDetail, FFIOutputDetail, FFITransactionContext,
+        FFITransactionContextType, FFITransactionDirection, FFITransactionType,
+    };
 
     use super::*;
+
+    fn empty_record() -> FFITransactionRecord {
+        FFITransactionRecord {
+            txid: [0u8; 32],
+            net_amount: 0,
+            context: FFITransactionContext {
+                context_type: FFITransactionContextType::Mempool,
+                block_info: FFIBlockInfo::empty(),
+                islock_data: ptr::null(),
+                islock_len: 0,
+            },
+            transaction_type: FFITransactionType::Standard,
+            direction: FFITransactionDirection::Incoming,
+            fee: 0,
+            input_details: ptr::null_mut(),
+            input_details_count: 0,
+            output_details: ptr::null_mut(),
+            output_details_count: 0,
+            tx_data: ptr::null_mut(),
+            tx_len: 0,
+            label: ptr::null_mut(),
+        }
+    }
+
+    #[test]
+    fn extract_ffi_inputs_null_pointer_returns_empty() {
+        let record = empty_record();
+        let result = extract_ffi_inputs(&record);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn extract_ffi_inputs_maps_index_value_address() {
+        let addr = CString::new("XqN8a73jYfHtFbEjz2XYBfrCHn6YQwBGsP").unwrap();
+        let mut detail = FFIInputDetail {
+            index: 2,
+            value: 150_000_000,
+            address: addr.as_ptr() as *mut _,
+        };
+        let mut record = empty_record();
+        record.input_details = &mut detail as *mut _;
+        record.input_details_count = 1;
+
+        let result = extract_ffi_inputs(&record);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].index, 2);
+        assert_eq!(result[0].value, 150_000_000);
+        assert_eq!(result[0].address, "XqN8a73jYfHtFbEjz2XYBfrCHn6YQwBGsP");
+    }
+
+    #[test]
+    fn extract_ffi_inputs_null_address_falls_back_to_empty_string() {
+        let mut detail = FFIInputDetail {
+            index: 0,
+            value: 0,
+            address: ptr::null_mut(),
+        };
+        let mut record = empty_record();
+        record.input_details = &mut detail as *mut _;
+        record.input_details_count = 1;
+
+        let result = extract_ffi_inputs(&record);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].address, "");
+    }
+
+    #[test]
+    fn extract_ffi_outputs_null_pointer_returns_empty() {
+        let record = empty_record();
+        let result = extract_ffi_outputs(&record, Network::Mainnet);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn extract_ffi_outputs_bad_tx_data_falls_back_to_zero_value_empty_address() {
+        let garbage: Vec<u8> = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let mut detail = FFIOutputDetail {
+            index: 0,
+            role: FFIOutputRole::Received,
+        };
+        let mut record = empty_record();
+        record.output_details = &mut detail as *mut _;
+        record.output_details_count = 1;
+        record.tx_data = garbage.as_ptr() as *mut _;
+        record.tx_len = garbage.len();
+
+        let result = extract_ffi_outputs(&record, Network::Mainnet);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].value, 0);
+        assert_eq!(result[0].address, "");
+        assert_eq!(result[0].role, OutputRole::Received);
+    }
+
+    #[test]
+    fn extract_ffi_outputs_oversized_tx_len_skips_enrichment() {
+        let mut detail = FFIOutputDetail {
+            index: 0,
+            role: FFIOutputRole::Change,
+        };
+        let dummy_byte: u8 = 0;
+        let mut record = empty_record();
+        record.output_details = &mut detail as *mut _;
+        record.output_details_count = 1;
+        record.tx_data = &dummy_byte as *const u8 as *mut _;
+        record.tx_len = 2_000_000;
+
+        let result = extract_ffi_outputs(&record, Network::Mainnet);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].value, 0);
+        assert_eq!(result[0].address, "");
+    }
 
     #[test]
     fn ffi_direction_to_direction_maps_all_variants() {

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1715,8 +1715,7 @@ fn extract_ffi_outputs(record: &FFITransactionRecord, network: Network) -> Vec<O
                 None
             } else {
                 // Safety: tx_data is a valid pointer for tx_len bytes.
-                let bytes =
-                    unsafe { std::slice::from_raw_parts(record.tx_data, record.tx_len) };
+                let bytes = unsafe { std::slice::from_raw_parts(record.tx_data, record.tx_len) };
                 let result = dashcore::consensus::deserialize(bytes);
                 if result.is_err() {
                     tracing::warn!(

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -10,8 +10,8 @@ use super::error::{BackendError, BackendResult};
 use super::events::{EventReceiver, EventSender, SpvEvent};
 use super::r#trait::SpvBackend;
 use super::types::{
-    Network, SyncProgress, TransactionDirection, TransactionInfo, TransactionType,
-    WalletCoreBalance,
+    InputInfo, Network, OutputInfo, OutputRole, SyncProgress, TransactionDirection,
+    TransactionInfo, TransactionType, WalletCoreBalance,
 };
 
 /// Builder for configuring a `MockBackend` instance.
@@ -277,12 +277,15 @@ fn mock_txid(index: u32) -> [u8; 32] {
     txid
 }
 
-/// Creates a test transaction record.
+/// Creates a test transaction record with sample I/O data.
 pub fn mock_transaction(
     index: u32,
     direction: TransactionDirection,
     amount: u64,
 ) -> TransactionInfo {
+    let addr = mock_address(index);
+    let change_addr = mock_address(index + 100);
+    let (inputs, outputs) = mock_io(direction, amount, &addr, &change_addr);
     TransactionInfo {
         txid: dashcore::Txid::from_byte_array(mock_txid(index)),
         amount: match direction {
@@ -294,13 +297,69 @@ pub fn mock_transaction(
         timestamp: 1700000000 + (index as u64 * 600),
         height: Some(1000 + index),
         fee: None,
-        addresses: vec![mock_address(index)],
+        addresses: vec![addr],
         block_hash: None,
         is_instant_send: false,
         is_chain_locked: false,
         label: None,
-        inputs: Vec::new(),
-        outputs: Vec::new(),
+        inputs,
+        outputs,
+    }
+}
+
+/// Generate representative input/output entries for a mock transaction.
+fn mock_io(
+    direction: TransactionDirection,
+    amount: u64,
+    addr: &str,
+    change_addr: &str,
+) -> (Vec<InputInfo>, Vec<OutputInfo>) {
+    match direction {
+        TransactionDirection::Incoming => {
+            let inputs = vec![InputInfo {
+                index: 0,
+                value: amount + 1000,
+                address: "XexternalSender0000000000000000001".into(),
+            }];
+            let outputs = vec![
+                OutputInfo {
+                    index: 0,
+                    value: amount,
+                    address: addr.to_string(),
+                    role: OutputRole::Received,
+                },
+                OutputInfo {
+                    index: 1,
+                    value: 1000,
+                    address: "XexternalSender0000000000000000001".into(),
+                    role: OutputRole::Sent,
+                },
+            ];
+            (inputs, outputs)
+        }
+        TransactionDirection::Outgoing => {
+            let inputs = vec![InputInfo {
+                index: 0,
+                value: amount + 5000,
+                address: change_addr.to_string(),
+            }];
+            let outputs = vec![
+                OutputInfo {
+                    index: 0,
+                    value: amount,
+                    address: addr.to_string(),
+                    role: OutputRole::Sent,
+                },
+                OutputInfo {
+                    index: 1,
+                    value: 5000,
+                    address: change_addr.to_string(),
+                    role: OutputRole::Change,
+                },
+            ];
+            (inputs, outputs)
+        }
+        _ => (Vec::new(), Vec::new()),
     }
 }
 

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -321,20 +321,12 @@ fn mock_io(
                 value: amount + 1000,
                 address: "XexternalSender0000000000000000001".into(),
             }];
-            let outputs = vec![
-                OutputInfo {
-                    index: 0,
-                    value: amount,
-                    address: addr.to_string(),
-                    role: OutputRole::Received,
-                },
-                OutputInfo {
-                    index: 1,
-                    value: 1000,
-                    address: "XexternalSender0000000000000000001".into(),
-                    role: OutputRole::Sent,
-                },
-            ];
+            let outputs = vec![OutputInfo {
+                index: 0,
+                value: amount,
+                address: addr.to_string(),
+                role: OutputRole::Received,
+            }];
             (inputs, outputs)
         }
         TransactionDirection::Outgoing => {

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -351,7 +351,7 @@ fn mock_io(
             ];
             (inputs, outputs)
         }
-        _ => (Vec::new(), Vec::new()),
+        TransactionDirection::Internal | TransactionDirection::CoinJoin => (Vec::new(), Vec::new()),
     }
 }
 
@@ -704,6 +704,26 @@ mod tests {
                 .iter()
                 .any(|o| o.role == OutputRole::Change),
             "outgoing tx must have a Change output",
+        );
+
+        let internal = mock_transaction(2, TransactionDirection::Internal, amount);
+        assert!(
+            internal.inputs.is_empty(),
+            "internal tx must have empty inputs"
+        );
+        assert!(
+            internal.outputs.is_empty(),
+            "internal tx must have empty outputs"
+        );
+
+        let coinjoin = mock_transaction(3, TransactionDirection::CoinJoin, amount);
+        assert!(
+            coinjoin.inputs.is_empty(),
+            "coinjoin tx must have empty inputs"
+        );
+        assert!(
+            coinjoin.outputs.is_empty(),
+            "coinjoin tx must have empty outputs"
         );
     }
 

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -671,6 +671,43 @@ mod tests {
     }
 
     #[test]
+    fn mock_transaction_populates_io_structure() {
+        let amount = 100_000;
+
+        let incoming = mock_transaction(0, TransactionDirection::Incoming, amount);
+        assert!(!incoming.inputs.is_empty(), "incoming tx must have inputs");
+        assert!(
+            !incoming.outputs.is_empty(),
+            "incoming tx must have outputs"
+        );
+        assert!(
+            incoming
+                .outputs
+                .iter()
+                .any(|o| o.role == OutputRole::Received),
+            "incoming tx must have a Received output",
+        );
+
+        let outgoing = mock_transaction(1, TransactionDirection::Outgoing, amount);
+        assert!(!outgoing.inputs.is_empty(), "outgoing tx must have inputs");
+        assert!(
+            !outgoing.outputs.is_empty(),
+            "outgoing tx must have outputs"
+        );
+        assert!(
+            outgoing.outputs.iter().any(|o| o.role == OutputRole::Sent),
+            "outgoing tx must have a Sent output",
+        );
+        assert!(
+            outgoing
+                .outputs
+                .iter()
+                .any(|o| o.role == OutputRole::Change),
+            "outgoing tx must have a Change output",
+        );
+    }
+
+    #[test]
     fn cache_size_returns_zero() {
         let backend = MockBackend::builder(Network::Testnet).build();
         assert_eq!(backend.cache_size().unwrap(), 0);

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -242,6 +242,8 @@ impl SpvBackend for MockBackend {
             is_instant_send: false,
             is_chain_locked: false,
             label: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         };
 
         self.transactions.lock().unwrap().push(record.clone());
@@ -297,6 +299,8 @@ pub fn mock_transaction(
         is_instant_send: false,
         is_chain_locked: false,
         label: None,
+        inputs: Vec::new(),
+        outputs: Vec::new(),
     }
 }
 

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -837,7 +837,9 @@ mod tests {
     use dashcore::ephemerealdata::instant_lock::InstantLock;
     use dashcore::hashes::Hash;
     use dashcore::{Address, BlockHash, PublicKey, Txid};
-    use key_wallet::managed_account::transaction_record::{InputDetail, TransactionRecord};
+    use key_wallet::managed_account::transaction_record::{
+        InputDetail, OutputDetail, OutputRole as UpstreamTestOutputRole, TransactionRecord,
+    };
     use key_wallet::transaction_checking::TransactionContext;
     use key_wallet::transaction_checking::transaction_context::BlockInfo;
     use key_wallet::transaction_checking::transaction_router::TransactionType;
@@ -1281,5 +1283,105 @@ mod tests {
         assert_eq!(addresses.len(), 2);
         assert!(addresses.contains(&addr_a.to_string()));
         assert!(addresses.contains(&addr_b.to_string()));
+    }
+
+    #[test]
+    fn extract_record_inputs_maps_index_value_address() {
+        let addr = test_address();
+        let input_details = vec![
+            InputDetail {
+                index: 0,
+                value: 50_000,
+                address: addr.clone(),
+            },
+            InputDetail {
+                index: 1,
+                value: 75_000,
+                address: addr.clone(),
+            },
+        ];
+
+        let tx = Transaction::dummy_empty();
+        let record = TransactionRecord::new(
+            tx,
+            TransactionContext::Mempool,
+            TransactionType::Standard,
+            TransactionDirection::Incoming,
+            input_details,
+            Vec::new(),
+            125_000,
+        );
+
+        let inputs = extract_record_inputs(&record);
+        assert_eq!(inputs.len(), 2);
+        assert_eq!(inputs[0].index, 0);
+        assert_eq!(inputs[0].value, 50_000);
+        assert_eq!(inputs[0].address, addr.to_string());
+        assert_eq!(inputs[1].index, 1);
+        assert_eq!(inputs[1].value, 75_000);
+    }
+
+    #[test]
+    fn extract_record_outputs_enriches_value_and_address_from_tx() {
+        let addr = test_address();
+        let tx = Transaction::dummy(&addr, 0..1, &[99_774, 226]);
+        let output_details = vec![
+            OutputDetail {
+                index: 0,
+                role: UpstreamTestOutputRole::Received,
+            },
+            OutputDetail {
+                index: 1,
+                role: UpstreamTestOutputRole::Change,
+            },
+        ];
+
+        let record = TransactionRecord::new(
+            tx,
+            TransactionContext::Mempool,
+            TransactionType::Standard,
+            TransactionDirection::Incoming,
+            Vec::new(),
+            output_details,
+            99_774,
+        );
+
+        let outputs = extract_record_outputs(&record, Network::Testnet);
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs[0].index, 0);
+        assert_eq!(outputs[0].value, 99_774);
+        assert_eq!(outputs[0].address, addr.to_string());
+        assert_eq!(outputs[0].role, OutputRole::Received);
+        assert_eq!(outputs[1].index, 1);
+        assert_eq!(outputs[1].value, 226);
+        assert_eq!(outputs[1].role, OutputRole::Change);
+    }
+
+    #[test]
+    fn extract_record_outputs_oob_index_falls_back_to_zero() {
+        let addr = test_address();
+        let tx = Transaction::dummy(&addr, 0..1, &[50_000]);
+        // index 99 is out of bounds for a 1-output tx
+        let output_details = vec![OutputDetail {
+            index: 99,
+            role: UpstreamTestOutputRole::Sent,
+        }];
+
+        let record = TransactionRecord::new(
+            tx,
+            TransactionContext::Mempool,
+            TransactionType::Standard,
+            TransactionDirection::Incoming,
+            Vec::new(),
+            output_details,
+            0,
+        );
+
+        let outputs = extract_record_outputs(&record, Network::Testnet);
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].index, 99);
+        assert_eq!(outputs[0].value, 0);
+        assert_eq!(outputs[0].address, "");
+        assert_eq!(outputs[0].role, OutputRole::Sent);
     }
 }

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -52,6 +52,7 @@ type SpvClient = DashSpvClient<
 struct NativeEventHandler {
     event_tx: EventSender,
     progress: Arc<RwLock<SyncProgress>>,
+    network: Network,
 }
 
 impl EventHandler for NativeEventHandler {
@@ -75,7 +76,9 @@ impl EventHandler for NativeEventHandler {
     }
 
     fn on_wallet_event(&self, event: &WalletEvent) {
-        let _ = self.event_tx.send(map_wallet_event(event.clone()));
+        let _ = self
+            .event_tx
+            .send(map_wallet_event(event.clone(), self.network));
     }
 
     fn on_error(&self, error: &str) {
@@ -183,6 +186,7 @@ impl SpvBackend for NativeBackend {
         let event_handler = Arc::new(NativeEventHandler {
             event_tx: self.event_tx.clone(),
             progress: self.progress.clone(),
+            network: self.config.network,
         });
 
         let client = Arc::new(
@@ -372,7 +376,7 @@ impl SpvBackend for NativeBackend {
 
         let mut transactions: Vec<TransactionInfo> = records
             .into_iter()
-            .map(|r| TransactionInfo::from_record(r, 0))
+            .map(|r| TransactionInfo::from_record(r, 0, self.config.network))
             .collect();
 
         // Sort: unconfirmed first, then by timestamp descending
@@ -653,7 +657,7 @@ fn map_network_event(event: NetworkEvent) -> SpvEvent {
     }
 }
 
-fn map_wallet_event(event: WalletEvent) -> SpvEvent {
+fn map_wallet_event(event: WalletEvent, network: Network) -> SpvEvent {
     match event {
         WalletEvent::TransactionReceived {
             wallet_id: _,
@@ -667,6 +671,7 @@ fn map_wallet_event(event: WalletEvent) -> SpvEvent {
             SpvEvent::TransactionReceived(Box::new(TransactionInfo::from_record(
                 &record,
                 fallback_timestamp,
+                network,
             )))
         }
         WalletEvent::TransactionStatusChanged { txid, status, .. } => {
@@ -715,12 +720,12 @@ impl TransactionInfo {
     /// timestamp (mempool / instant-send).  Pass `0` for cold-start loads
     /// (renders as "Pending") or the current unix time for live events
     /// (renders as "just now").
-    fn from_record(record: &TransactionRecord, fallback_timestamp: u64) -> Self {
+    fn from_record(record: &TransactionRecord, fallback_timestamp: u64, network: Network) -> Self {
         let (height, timestamp, block_hash, is_instant_send, is_chain_locked) =
             extract_context_fields(&record.context);
         let addresses = extract_record_addresses(record);
         let inputs = extract_record_inputs(record);
-        let outputs = extract_record_outputs(record);
+        let outputs = extract_record_outputs(record, network);
         TransactionInfo {
             txid: record.txid,
             amount: record.net_amount,
@@ -767,7 +772,7 @@ fn extract_record_inputs(record: &TransactionRecord) -> Vec<InputInfo> {
 
 /// Build `OutputInfo` entries from a transaction record's output details,
 /// enriching them with value and address from the raw transaction outputs.
-fn extract_record_outputs(record: &TransactionRecord) -> Vec<OutputInfo> {
+fn extract_record_outputs(record: &TransactionRecord, network: Network) -> Vec<OutputInfo> {
     record
         .output_details
         .iter()
@@ -775,10 +780,7 @@ fn extract_record_outputs(record: &TransactionRecord) -> Vec<OutputInfo> {
             let tx_out = record.transaction.output.get(d.index as usize);
             let value = tx_out.map_or(0, |o| o.value);
             let address = tx_out
-                .and_then(|o| {
-                    dashcore::Address::from_script(&o.script_pubkey, dashcore::Network::Mainnet)
-                        .ok()
-                })
+                .and_then(|o| dashcore::Address::from_script(&o.script_pubkey, network).ok())
                 .map_or_else(String::new, |a| a.to_string());
             OutputInfo {
                 index: d.index,
@@ -1130,7 +1132,7 @@ mod tests {
             account_index: 0,
             record: Box::new(record),
         };
-        let mapped = map_wallet_event(event);
+        let mapped = map_wallet_event(event, Network::Mainnet);
         match mapped {
             SpvEvent::TransactionReceived(info) => {
                 assert_eq!(info.txid, txid);
@@ -1158,7 +1160,7 @@ mod tests {
                 1700000000,
             )),
         };
-        let mapped = map_wallet_event(event);
+        let mapped = map_wallet_event(event, Network::Mainnet);
         match mapped {
             SpvEvent::TransactionReceived(info) => {
                 assert_eq!(info.amount, 0);
@@ -1181,7 +1183,7 @@ mod tests {
             immature: 25_000,
             locked: 10_000,
         };
-        let mapped = map_wallet_event(event);
+        let mapped = map_wallet_event(event, Network::Mainnet);
         assert_eq!(
             mapped,
             SpvEvent::BalanceUpdated(WalletCoreBalance::new(100_000, 50_000, 25_000, 10_000))
@@ -1202,7 +1204,7 @@ mod tests {
             42000,
         );
 
-        let info = TransactionInfo::from_record(&record, 9999999999);
+        let info = TransactionInfo::from_record(&record, 9999999999, Network::Mainnet);
 
         assert_eq!(info.timestamp, 1700000000);
         assert_eq!(info.height, Some(500));
@@ -1223,7 +1225,7 @@ mod tests {
             10000,
         );
 
-        let info = TransactionInfo::from_record(&record, 0);
+        let info = TransactionInfo::from_record(&record, 0, Network::Mainnet);
 
         assert_eq!(info.timestamp, 0);
         assert_eq!(info.height, None);

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -778,6 +778,13 @@ fn extract_record_outputs(record: &TransactionRecord, network: Network) -> Vec<O
         .iter()
         .map(|d| {
             let tx_out = record.transaction.output.get(d.index as usize);
+            if tx_out.is_none() {
+                tracing::warn!(
+                    requested_index = d.index,
+                    actual_len = record.transaction.output.len(),
+                    "native output index out of bounds, returning zero value and empty address"
+                );
+            }
             let value = tx_out.map_or(0, |o| o.value);
             let address = tx_out
                 .and_then(|o| dashcore::Address::from_script(&o.script_pubkey, network).ok())

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -14,7 +14,9 @@ use dash_spv::sync::SyncEvent;
 use dash_spv::{ClientConfig, DashSpvClient, MempoolStrategy};
 use dashcore::hashes::Hash;
 use key_wallet::managed_account::managed_account_type::ManagedAccountType;
-use key_wallet::managed_account::transaction_record::TransactionRecord;
+use key_wallet::managed_account::transaction_record::{
+    OutputRole as UpstreamOutputRole, TransactionRecord,
+};
 use key_wallet::mnemonic::Language;
 use key_wallet::transaction_checking::TransactionContext;
 use key_wallet::wallet::initialization::WalletAccountCreationOptions;
@@ -34,8 +36,8 @@ use super::error::{BackendError, BackendResult};
 use super::events::{EventReceiver, EventSender, SpvEvent, event_channel};
 use super::r#trait::SpvBackend;
 use super::types::{
-    Network, SyncProgress, TransactionDirection, TransactionInfo, TransactionType,
-    WalletCoreBalance,
+    InputInfo, Network, OutputInfo, OutputRole, SyncProgress, TransactionDirection,
+    TransactionInfo, TransactionType, WalletCoreBalance,
 };
 use crate::config::AppConfig;
 
@@ -687,6 +689,8 @@ fn map_wallet_event(event: WalletEvent) -> SpvEvent {
                 is_instant_send,
                 is_chain_locked,
                 label: None,
+                inputs: Vec::new(),
+                outputs: Vec::new(),
             }))
         }
         WalletEvent::BalanceUpdated {
@@ -715,6 +719,8 @@ impl TransactionInfo {
         let (height, timestamp, block_hash, is_instant_send, is_chain_locked) =
             extract_context_fields(&record.context);
         let addresses = extract_record_addresses(record);
+        let inputs = extract_record_inputs(record);
+        let outputs = extract_record_outputs(record);
         TransactionInfo {
             txid: record.txid,
             amount: record.net_amount,
@@ -728,6 +734,8 @@ impl TransactionInfo {
             is_instant_send,
             is_chain_locked,
             label: record.label.clone(),
+            inputs,
+            outputs,
         }
     }
 }
@@ -742,6 +750,53 @@ fn extract_record_addresses(record: &TransactionRecord) -> Vec<String> {
     addrs.sort();
     addrs.dedup();
     addrs
+}
+
+/// Build `InputInfo` entries from a transaction record's input details.
+fn extract_record_inputs(record: &TransactionRecord) -> Vec<InputInfo> {
+    record
+        .input_details
+        .iter()
+        .map(|d| InputInfo {
+            index: d.index,
+            value: d.value,
+            address: d.address.to_string(),
+        })
+        .collect()
+}
+
+/// Build `OutputInfo` entries from a transaction record's output details,
+/// enriching them with value and address from the raw transaction outputs.
+fn extract_record_outputs(record: &TransactionRecord) -> Vec<OutputInfo> {
+    record
+        .output_details
+        .iter()
+        .map(|d| {
+            let tx_out = record.transaction.output.get(d.index as usize);
+            let value = tx_out.map_or(0, |o| o.value);
+            let address = tx_out
+                .and_then(|o| {
+                    dashcore::Address::from_script(&o.script_pubkey, dashcore::Network::Mainnet)
+                        .ok()
+                })
+                .map_or_else(String::new, |a| a.to_string());
+            OutputInfo {
+                index: d.index,
+                value,
+                address,
+                role: map_output_role(d.role),
+            }
+        })
+        .collect()
+}
+
+fn map_output_role(role: UpstreamOutputRole) -> OutputRole {
+    match role {
+        UpstreamOutputRole::Received => OutputRole::Received,
+        UpstreamOutputRole::Change => OutputRole::Change,
+        UpstreamOutputRole::Sent => OutputRole::Sent,
+        UpstreamOutputRole::Unspendable => OutputRole::Unspendable,
+    }
 }
 
 /// Extract UI-relevant fields from a `TransactionContext`.

--- a/src/backend/types.rs
+++ b/src/backend/types.rs
@@ -5,6 +5,43 @@ pub use key_wallet::WalletCoreBalance;
 pub use key_wallet::managed_account::transaction_record::TransactionDirection;
 pub use key_wallet::transaction_checking::transaction_router::TransactionType;
 
+/// Role of a transaction output from the wallet's perspective.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputRole {
+    /// Output to our external/receive address.
+    Received,
+    /// Output to our internal/change address.
+    Change,
+    /// Output to counterparty address.
+    Sent,
+    /// Unspendable output (OP_RETURN, non-standard, bare multisig).
+    Unspendable,
+}
+
+/// Wallet-context metadata for a transaction input.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InputInfo {
+    /// Index into the transaction's input array.
+    pub index: u32,
+    /// Value of the UTXO being spent (satoshis).
+    pub value: u64,
+    /// Address that owned the spent UTXO.
+    pub address: String,
+}
+
+/// Wallet-context metadata for a transaction output.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OutputInfo {
+    /// Index into the transaction's output array.
+    pub index: u32,
+    /// Value of this output (satoshis).
+    pub value: u64,
+    /// Address receiving this output.
+    pub address: String,
+    /// Role from the wallet's perspective.
+    pub role: OutputRole,
+}
+
 /// A UI-facing transaction record assembled from wallet events and sync state.
 ///
 /// This combines data from key-wallet's `TransactionRecord` (txid, amount, height,
@@ -23,6 +60,8 @@ pub struct TransactionInfo {
     pub is_instant_send: bool,
     pub is_chain_locked: bool,
     pub label: Option<String>,
+    pub inputs: Vec<InputInfo>,
+    pub outputs: Vec<OutputInfo>,
 }
 
 impl TransactionInfo {

--- a/src/event_bridge.rs
+++ b/src/event_bridge.rs
@@ -125,6 +125,8 @@ mod tests {
             is_instant_send: false,
             is_chain_locked: true,
             label: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         }));
 
         dispatch_event(&event, &mut conn, &mut wallet, &mut net, &mut log);
@@ -381,6 +383,8 @@ mod tests {
                 is_instant_send: true,
                 is_chain_locked: false,
                 label: None,
+                inputs: Vec::new(),
+                outputs: Vec::new(),
             })),
             SpvEvent::BalanceUpdated(WalletCoreBalance::new(1_000_000, 0, 0, 0)),
             SpvEvent::SyncComplete {

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -179,10 +179,12 @@ pub fn Transactions() -> Element {
                                         }
                                     },
                                     on_toggle_inputs: move |_| {
-                                        inputs_expanded.set(!*inputs_expanded.read());
+                                        let current = *inputs_expanded.read();
+                                        inputs_expanded.set(!current);
                                     },
                                     on_toggle_outputs: move |_| {
-                                        outputs_expanded.set(!*outputs_expanded.read());
+                                        let current = *outputs_expanded.read();
+                                        outputs_expanded.set(!current);
                                     },
                                 }
                             }

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -354,7 +354,11 @@ fn TransactionRow(
                                         button {
                                             class: "text-dash text-xs mt-1 hover:underline",
                                             onclick: move |e| on_toggle_inputs.call(e),
-                                            if show_all_inputs { "Show less" } else { "Show all {input_count} inputs" }
+                                            if show_all_inputs {
+                                                "Show less"
+                                            } else {
+                                                "Show all {input_count} inputs"
+                                            }
                                         }
                                     }
                                 }
@@ -396,7 +400,11 @@ fn TransactionRow(
                                         button {
                                             class: "text-dash text-xs mt-1 hover:underline",
                                             onclick: move |e| on_toggle_outputs.call(e),
-                                            if show_all_outputs { "Show less" } else { "Show all {output_count} outputs" }
+                                            if show_all_outputs {
+                                                "Show less"
+                                            } else {
+                                                "Show all {output_count} outputs"
+                                            }
                                         }
                                     }
                                 }

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -179,10 +179,10 @@ pub fn Transactions() -> Element {
                                         }
                                     },
                                     on_toggle_inputs: move |_| {
-                                        inputs_expanded.set(true);
+                                        inputs_expanded.set(!*inputs_expanded.read());
                                     },
                                     on_toggle_outputs: move |_| {
-                                        outputs_expanded.set(true);
+                                        outputs_expanded.set(!*outputs_expanded.read());
                                     },
                                 }
                             }
@@ -348,11 +348,11 @@ fn TransactionRow(
                                             }
                                         }
                                     }
-                                    if input_count > collapse_threshold && !show_all_inputs {
+                                    if input_count > collapse_threshold {
                                         button {
                                             class: "text-dash text-xs mt-1 hover:underline",
                                             onclick: move |e| on_toggle_inputs.call(e),
-                                            "Show all {input_count} inputs"
+                                            if show_all_inputs { "Show less" } else { "Show all {input_count} inputs" }
                                         }
                                     }
                                 }
@@ -390,11 +390,11 @@ fn TransactionRow(
                                             }
                                         }
                                     }
-                                    if output_count > collapse_threshold && !show_all_outputs {
+                                    if output_count > collapse_threshold {
                                         button {
                                             class: "text-dash text-xs mt-1 hover:underline",
                                             onclick: move |e| on_toggle_outputs.call(e),
-                                            "Show all {output_count} outputs"
+                                            if show_all_outputs { "Show less" } else { "Show all {output_count} outputs" }
                                         }
                                     }
                                 }

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use dioxus::prelude::*;
 
 use crate::backend::types::{InputInfo, OutputInfo, TransactionDirection, TransactionInfo};
@@ -161,9 +163,9 @@ pub fn Transactions() -> Element {
                                     confirmations,
                                     height: tx.height,
                                     is_expanded,
-                                    addresses: tx.addresses.clone(),
-                                    inputs: tx.inputs.clone(),
-                                    outputs: tx.outputs.clone(),
+                                    addresses: tx.addresses,
+                                    inputs: Rc::new(tx.inputs),
+                                    outputs: Rc::new(tx.outputs),
                                     unit: unit.to_string(),
                                     onclick: move |_| {
                                         if *expanded_txid.read() == Some(txid) {
@@ -207,8 +209,8 @@ fn TransactionRow(
     height: Option<u32>,
     is_expanded: bool,
     addresses: Vec<String>,
-    inputs: Vec<InputInfo>,
-    outputs: Vec<OutputInfo>,
+    inputs: Rc<Vec<InputInfo>>,
+    outputs: Rc<Vec<OutputInfo>>,
     unit: String,
     onclick: EventHandler<MouseEvent>,
 ) -> Element {

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -326,6 +326,8 @@ mod tests {
                 is_instant_send: false,
                 is_chain_locked: false,
                 label: None,
+                inputs: Vec::new(),
+                outputs: Vec::new(),
             },
             TransactionInfo {
                 txid: dashcore::Txid::from_byte_array([0xBB; 32]),
@@ -340,6 +342,8 @@ mod tests {
                 is_instant_send: false,
                 is_chain_locked: false,
                 label: None,
+                inputs: Vec::new(),
+                outputs: Vec::new(),
             },
             TransactionInfo {
                 txid: dashcore::Txid::from_byte_array([0xCC; 32]),
@@ -354,6 +358,8 @@ mod tests {
                 is_instant_send: true,
                 is_chain_locked: false,
                 label: None,
+                inputs: Vec::new(),
+                outputs: Vec::new(),
             },
         ]
     }
@@ -431,6 +437,8 @@ mod tests {
             is_instant_send: false,
             is_chain_locked: false,
             label: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         });
 
         let result = apply_filters(&txs, Some(TransactionDirection::Internal), "", "DASH");
@@ -454,6 +462,8 @@ mod tests {
             is_instant_send: false,
             is_chain_locked: false,
             label: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         });
 
         let result = apply_filters(&txs, Some(TransactionDirection::CoinJoin), "", "DASH");

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -4,8 +4,8 @@ use crate::backend::types::{InputInfo, OutputInfo, TransactionDirection, Transac
 use crate::config::AppConfig;
 use crate::state::network::NetworkInfo;
 use crate::state::view_models::{
-    TransactionView, format_address_responsive, format_input, format_output, format_transaction,
-    matches_search,
+    COLLAPSE_THRESHOLD, TransactionView, format_address_responsive, format_transaction,
+    matches_search, visible_input_views, visible_output_views,
 };
 use crate::state::wallet::WalletState;
 
@@ -55,8 +55,6 @@ pub fn Transactions() -> Element {
     let mut active_filter = use_signal(|| None::<TransactionDirection>);
     let mut visible_count = use_signal(|| PAGE_SIZE);
     let mut expanded_txid = use_signal(|| None::<dashcore::Txid>);
-    let mut inputs_expanded = use_signal(|| false);
-    let mut outputs_expanded = use_signal(|| false);
 
     let transactions = wallet.read().transactions.clone();
     let current_height = network_info.read().chain_tip;
@@ -167,24 +165,12 @@ pub fn Transactions() -> Element {
                                     inputs: tx.inputs.clone(),
                                     outputs: tx.outputs.clone(),
                                     unit: unit.to_string(),
-                                    inputs_expanded: *inputs_expanded.read(),
-                                    outputs_expanded: *outputs_expanded.read(),
                                     onclick: move |_| {
                                         if *expanded_txid.read() == Some(txid) {
                                             expanded_txid.set(None);
                                         } else {
                                             expanded_txid.set(Some(txid));
-                                            inputs_expanded.set(false);
-                                            outputs_expanded.set(false);
                                         }
-                                    },
-                                    on_toggle_inputs: move |_| {
-                                        let current = *inputs_expanded.read();
-                                        inputs_expanded.set(!current);
-                                    },
-                                    on_toggle_outputs: move |_| {
-                                        let current = *outputs_expanded.read();
-                                        outputs_expanded.set(!current);
                                     },
                                 }
                             }
@@ -224,12 +210,11 @@ fn TransactionRow(
     inputs: Vec<InputInfo>,
     outputs: Vec<OutputInfo>,
     unit: String,
-    inputs_expanded: bool,
-    outputs_expanded: bool,
     onclick: EventHandler<MouseEvent>,
-    on_toggle_inputs: EventHandler<MouseEvent>,
-    on_toggle_outputs: EventHandler<MouseEvent>,
 ) -> Element {
+    let mut inputs_expanded = use_signal(|| false);
+    let mut outputs_expanded = use_signal(|| false);
+
     let border = view.border_class;
     let icon_class = view.direction_icon_class;
     let icon = view.direction_icon;
@@ -326,18 +311,13 @@ fn TransactionRow(
                     if !inputs.is_empty() {
                         {
                             let input_count = inputs.len();
-                            let collapse_threshold = 5;
-                            let show_all_inputs = inputs_expanded || input_count <= collapse_threshold;
-                            let visible_inputs = if show_all_inputs {
-                                input_count
-                            } else {
-                                collapse_threshold
-                            };
-                            let input_views: Vec<_> = inputs
-                                .iter()
-                                .take(visible_inputs)
-                                .map(|inp| format_input(inp, &unit))
-                                .collect();
+                            let (input_views, has_more_inputs) = visible_input_views(
+                                &inputs,
+                                *inputs_expanded.read(),
+                                COLLAPSE_THRESHOLD,
+                                &unit,
+                            );
+                            let show_all_inputs = *inputs_expanded.read() || !has_more_inputs;
                             rsx! {
                                 div { class: "mt-2 pt-2 border-t border-edge",
                                     span { class: "text-muted font-medium block mb-1", "Inputs ({input_count})" }
@@ -350,10 +330,14 @@ fn TransactionRow(
                                             }
                                         }
                                     }
-                                    if input_count > collapse_threshold {
+                                    if has_more_inputs {
                                         button {
                                             class: "text-dash text-xs mt-1 hover:underline",
-                                            onclick: move |e| on_toggle_inputs.call(e),
+                                            onclick: move |e| {
+                                                e.stop_propagation();
+                                                let current = *inputs_expanded.read();
+                                                inputs_expanded.set(!current);
+                                            },
                                             if show_all_inputs {
                                                 "Show less"
                                             } else {
@@ -369,18 +353,13 @@ fn TransactionRow(
                     if !outputs.is_empty() {
                         {
                             let output_count = outputs.len();
-                            let collapse_threshold = 5;
-                            let show_all_outputs = outputs_expanded || output_count <= collapse_threshold;
-                            let visible_outputs = if show_all_outputs {
-                                output_count
-                            } else {
-                                collapse_threshold
-                            };
-                            let output_views: Vec<_> = outputs
-                                .iter()
-                                .take(visible_outputs)
-                                .map(|out| format_output(out, &unit))
-                                .collect();
+                            let (output_views, has_more_outputs) = visible_output_views(
+                                &outputs,
+                                *outputs_expanded.read(),
+                                COLLAPSE_THRESHOLD,
+                                &unit,
+                            );
+                            let show_all_outputs = *outputs_expanded.read() || !has_more_outputs;
                             rsx! {
                                 div { class: "mt-2 pt-2 border-t border-edge",
                                     span { class: "text-muted font-medium block mb-1", "Outputs ({output_count})" }
@@ -396,10 +375,14 @@ fn TransactionRow(
                                             }
                                         }
                                     }
-                                    if output_count > collapse_threshold {
+                                    if has_more_outputs {
                                         button {
                                             class: "text-dash text-xs mt-1 hover:underline",
-                                            onclick: move |e| on_toggle_outputs.call(e),
+                                            onclick: move |e| {
+                                                e.stop_propagation();
+                                                let current = *outputs_expanded.read();
+                                                outputs_expanded.set(!current);
+                                            },
                                             if show_all_outputs {
                                                 "Show less"
                                             } else {
@@ -413,9 +396,7 @@ fn TransactionRow(
                     }
 
                     div { class: "mt-2 pt-2 border-t border-edge text-center",
-                        span { class: "text-dash text-xs cursor-pointer hover:underline",
-                            "View full details"
-                        }
+                        span { class: "text-muted text-xs", "View full details" }
                     }
                 }
             }

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -325,8 +325,7 @@ fn TransactionRow(
                         {
                             let input_count = inputs.len();
                             let collapse_threshold = 5;
-                            let show_all_inputs = inputs_expanded
-                                || input_count <= collapse_threshold;
+                            let show_all_inputs = inputs_expanded || input_count <= collapse_threshold;
                             let visible_inputs = if show_all_inputs {
                                 input_count
                             } else {
@@ -365,8 +364,7 @@ fn TransactionRow(
                         {
                             let output_count = outputs.len();
                             let collapse_threshold = 5;
-                            let show_all_outputs = outputs_expanded
-                                || output_count <= collapse_threshold;
+                            let show_all_outputs = outputs_expanded || output_count <= collapse_threshold;
                             let visible_outputs = if show_all_outputs {
                                 output_count
                             } else {
@@ -405,7 +403,9 @@ fn TransactionRow(
                     }
 
                     div { class: "mt-2 pt-2 border-t border-edge text-center",
-                        span { class: "text-dash text-xs cursor-pointer hover:underline", "View full details" }
+                        span { class: "text-dash text-xs cursor-pointer hover:underline",
+                            "View full details"
+                        }
                     }
                 }
             }

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -4,7 +4,8 @@ use crate::backend::types::{TransactionDirection, TransactionInfo};
 use crate::config::AppConfig;
 use crate::state::network::NetworkInfo;
 use crate::state::view_models::{
-    TransactionView, format_address_responsive, format_transaction, matches_search,
+    TransactionView, format_address_responsive, format_input, format_output, format_transaction,
+    matches_search,
 };
 use crate::state::wallet::WalletState;
 
@@ -54,6 +55,8 @@ pub fn Transactions() -> Element {
     let mut active_filter = use_signal(|| None::<TransactionDirection>);
     let mut visible_count = use_signal(|| PAGE_SIZE);
     let mut expanded_txid = use_signal(|| None::<dashcore::Txid>);
+    let mut inputs_expanded = use_signal(|| false);
+    let mut outputs_expanded = use_signal(|| false);
 
     let transactions = wallet.read().transactions.clone();
     let current_height = network_info.read().chain_tip;
@@ -161,12 +164,25 @@ pub fn Transactions() -> Element {
                                     height: tx.height,
                                     is_expanded,
                                     addresses: tx.addresses.clone(),
+                                    inputs: tx.inputs.clone(),
+                                    outputs: tx.outputs.clone(),
+                                    unit: unit.to_string(),
+                                    inputs_expanded: *inputs_expanded.read(),
+                                    outputs_expanded: *outputs_expanded.read(),
                                     onclick: move |_| {
                                         if *expanded_txid.read() == Some(txid) {
                                             expanded_txid.set(None);
                                         } else {
                                             expanded_txid.set(Some(txid));
+                                            inputs_expanded.set(false);
+                                            outputs_expanded.set(false);
                                         }
+                                    },
+                                    on_toggle_inputs: move |_| {
+                                        inputs_expanded.set(true);
+                                    },
+                                    on_toggle_outputs: move |_| {
+                                        outputs_expanded.set(true);
                                     },
                                 }
                             }
@@ -203,7 +219,14 @@ fn TransactionRow(
     height: Option<u32>,
     is_expanded: bool,
     addresses: Vec<String>,
+    inputs: Vec<crate::backend::types::InputInfo>,
+    outputs: Vec<crate::backend::types::OutputInfo>,
+    unit: String,
+    inputs_expanded: bool,
+    outputs_expanded: bool,
     onclick: EventHandler<MouseEvent>,
+    on_toggle_inputs: EventHandler<MouseEvent>,
+    on_toggle_outputs: EventHandler<MouseEvent>,
 ) -> Element {
     let border = view.border_class;
     let icon_class = view.direction_icon_class;
@@ -296,6 +319,93 @@ fn TransactionRow(
                         for addr in &addresses {
                             p { class: "font-mono text-xs select-all", "{addr}" }
                         }
+                    }
+
+                    if !inputs.is_empty() {
+                        {
+                            let input_count = inputs.len();
+                            let collapse_threshold = 5;
+                            let show_all_inputs = inputs_expanded
+                                || input_count <= collapse_threshold;
+                            let visible_inputs = if show_all_inputs {
+                                input_count
+                            } else {
+                                collapse_threshold
+                            };
+                            let input_views: Vec<_> = inputs
+                                .iter()
+                                .take(visible_inputs)
+                                .map(|inp| format_input(inp, &unit))
+                                .collect();
+                            rsx! {
+                                div { class: "mt-2 pt-2 border-t border-edge",
+                                    span { class: "text-muted font-medium block mb-1", "Inputs ({input_count})" }
+                                    div { class: "space-y-1",
+                                        for iv in &input_views {
+                                            div { class: "flex items-center gap-2 text-xs",
+                                                span { class: "text-disabled w-6", "#{iv.index}" }
+                                                span { class: "font-mono truncate flex-1", "{iv.address_short}" }
+                                                span { class: "text-foreground font-medium", "{iv.amount_display}" }
+                                            }
+                                        }
+                                    }
+                                    if input_count > collapse_threshold && !show_all_inputs {
+                                        button {
+                                            class: "text-dash text-xs mt-1 hover:underline",
+                                            onclick: move |e| on_toggle_inputs.call(e),
+                                            "Show all {input_count} inputs"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if !outputs.is_empty() {
+                        {
+                            let output_count = outputs.len();
+                            let collapse_threshold = 5;
+                            let show_all_outputs = outputs_expanded
+                                || output_count <= collapse_threshold;
+                            let visible_outputs = if show_all_outputs {
+                                output_count
+                            } else {
+                                collapse_threshold
+                            };
+                            let output_views: Vec<_> = outputs
+                                .iter()
+                                .take(visible_outputs)
+                                .map(|out| format_output(out, &unit))
+                                .collect();
+                            rsx! {
+                                div { class: "mt-2 pt-2 border-t border-edge",
+                                    span { class: "text-muted font-medium block mb-1", "Outputs ({output_count})" }
+                                    div { class: "space-y-1",
+                                        for ov in &output_views {
+                                            div { class: "flex items-center gap-2 text-xs",
+                                                span { class: "text-disabled w-6", "#{ov.index}" }
+                                                span { class: "font-mono truncate flex-1", "{ov.address_short}" }
+                                                span { class: "text-foreground font-medium", "{ov.amount_display}" }
+                                                span { class: "{ov.role_color} text-foreground rounded-full px-2 py-0.5 text-xs",
+                                                    "{ov.role_label}"
+                                                }
+                                            }
+                                        }
+                                    }
+                                    if output_count > collapse_threshold && !show_all_outputs {
+                                        button {
+                                            class: "text-dash text-xs mt-1 hover:underline",
+                                            onclick: move |e| on_toggle_outputs.call(e),
+                                            "Show all {output_count} outputs"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    div { class: "mt-2 pt-2 border-t border-edge text-center",
+                        span { class: "text-dash text-xs cursor-pointer hover:underline", "View full details" }
                     }
                 }
             }

--- a/src/screens/transactions.rs
+++ b/src/screens/transactions.rs
@@ -1,6 +1,6 @@
 use dioxus::prelude::*;
 
-use crate::backend::types::{TransactionDirection, TransactionInfo};
+use crate::backend::types::{InputInfo, OutputInfo, TransactionDirection, TransactionInfo};
 use crate::config::AppConfig;
 use crate::state::network::NetworkInfo;
 use crate::state::view_models::{
@@ -219,8 +219,8 @@ fn TransactionRow(
     height: Option<u32>,
     is_expanded: bool,
     addresses: Vec<String>,
-    inputs: Vec<crate::backend::types::InputInfo>,
-    outputs: Vec<crate::backend::types::OutputInfo>,
+    inputs: Vec<InputInfo>,
+    outputs: Vec<OutputInfo>,
     unit: String,
     inputs_expanded: bool,
     outputs_expanded: bool,

--- a/src/state/dev_log.rs
+++ b/src/state/dev_log.rs
@@ -283,6 +283,8 @@ mod tests {
                     is_instant_send: false,
                     is_chain_locked: false,
                     label: None,
+                    inputs: Vec::new(),
+                    outputs: Vec::new(),
                 })),
                 EventCategory::Wallet,
             ),

--- a/src/state/view_models.rs
+++ b/src/state/view_models.rs
@@ -1,4 +1,6 @@
-use crate::backend::types::{TransactionDirection, TransactionInfo, TransactionType};
+use crate::backend::types::{
+    InputInfo, OutputInfo, OutputRole, TransactionDirection, TransactionInfo, TransactionType,
+};
 
 const SATS_PER_DASH: u64 = 100_000_000;
 
@@ -337,6 +339,55 @@ pub fn format_transaction(
         height_display,
         is_instant_send: tx.is_instant_send,
         is_chain_locked: tx.is_chain_locked,
+    }
+}
+
+/// Display-ready transaction input.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InputView {
+    pub index: u32,
+    pub address_short: String,
+    pub amount_display: String,
+}
+
+/// Display-ready transaction output.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OutputView {
+    pub index: u32,
+    pub address_short: String,
+    pub amount_display: String,
+    pub role_label: &'static str,
+    pub role_color: &'static str,
+}
+
+/// Format a transaction input for display.
+pub fn format_input(input: &InputInfo, unit: &str) -> InputView {
+    InputView {
+        index: input.index,
+        address_short: format_address_short(&input.address),
+        amount_display: format_balance(input.value, unit),
+    }
+}
+
+/// Format a transaction output for display.
+pub fn format_output(output: &OutputInfo, unit: &str) -> OutputView {
+    let (role_label, role_color) = role_display(output.role);
+    OutputView {
+        index: output.index,
+        address_short: format_address_short(&output.address),
+        amount_display: format_balance(output.value, unit),
+        role_label,
+        role_color,
+    }
+}
+
+/// Map an `OutputRole` to a human-readable label and Tailwind color class.
+fn role_display(role: OutputRole) -> (&'static str, &'static str) {
+    match role {
+        OutputRole::Received => ("Received", "bg-success"),
+        OutputRole::Change => ("Change", "bg-muted"),
+        OutputRole::Sent => ("Sent", "bg-error"),
+        OutputRole::Unspendable => ("Unspendable", "bg-disabled"),
     }
 }
 
@@ -904,5 +955,57 @@ mod tests {
     fn format_timestamp_absolute_leap_year() {
         // 2024-02-29 00:00:00 UTC = 1709164800
         assert_eq!(format_timestamp_absolute(1709164800), "2024-02-29 00:00:00",);
+    }
+
+    // -- format_input / format_output --
+
+    #[test]
+    fn format_input_displays_correctly() {
+        let input = InputInfo {
+            index: 0,
+            value: 150_000_000,
+            address: "XqN8a73jYfHtFbEjz2XYBfrCHn6YQwBGsP".into(),
+        };
+        let view = format_input(&input, "DASH");
+        assert_eq!(view.index, 0);
+        assert_eq!(view.address_short, "XqN8...BGsP");
+        assert_eq!(view.amount_display, "1.5 DASH");
+    }
+
+    #[test]
+    fn format_output_received() {
+        let output = OutputInfo {
+            index: 0,
+            value: 100_000_000,
+            address: "XqN8a73jYfHtFbEjz2XYBfrCHn6YQwBGsP".into(),
+            role: OutputRole::Received,
+        };
+        let view = format_output(&output, "DASH");
+        assert_eq!(view.index, 0);
+        assert_eq!(view.address_short, "XqN8...BGsP");
+        assert_eq!(view.amount_display, "1.0 DASH");
+        assert_eq!(view.role_label, "Received");
+        assert_eq!(view.role_color, "bg-success");
+    }
+
+    #[test]
+    fn format_output_all_roles() {
+        let make = |role| OutputInfo {
+            index: 0,
+            value: 0,
+            address: String::new(),
+            role,
+        };
+        let change = format_output(&make(OutputRole::Change), "DASH");
+        assert_eq!(change.role_label, "Change");
+        assert_eq!(change.role_color, "bg-muted");
+
+        let sent = format_output(&make(OutputRole::Sent), "DASH");
+        assert_eq!(sent.role_label, "Sent");
+        assert_eq!(sent.role_color, "bg-error");
+
+        let unspendable = format_output(&make(OutputRole::Unspendable), "DASH");
+        assert_eq!(unspendable.role_label, "Unspendable");
+        assert_eq!(unspendable.role_color, "bg-disabled");
     }
 }

--- a/src/state/view_models.rs
+++ b/src/state/view_models.rs
@@ -533,6 +533,8 @@ mod tests {
             is_instant_send: true,
             is_chain_locked: false,
             label: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         };
 
         let view = format_transaction(&tx, 1000, "DASH");
@@ -571,6 +573,8 @@ mod tests {
             is_instant_send: false,
             is_chain_locked: false,
             label: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         };
 
         let view = format_transaction(&tx, 1000, "DASH");
@@ -604,6 +608,8 @@ mod tests {
             is_instant_send: false,
             is_chain_locked: false,
             label: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         };
 
         let view = format_transaction(&tx, 1000, "tDASH");
@@ -625,6 +631,8 @@ mod tests {
             is_instant_send: false,
             is_chain_locked: false,
             label: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         };
 
         let view = format_transaction(&tx, 1000, "DASH");
@@ -654,6 +662,8 @@ mod tests {
             is_instant_send: false,
             is_chain_locked: false,
             label: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         };
 
         let view = format_transaction(&tx, 1000, "DASH");
@@ -682,6 +692,8 @@ mod tests {
             is_instant_send: false,
             is_chain_locked: false,
             label: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         };
 
         assert_eq!(
@@ -800,6 +812,8 @@ mod tests {
             is_instant_send: false,
             is_chain_locked: false,
             label: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         }
     }
 

--- a/src/state/view_models.rs
+++ b/src/state/view_models.rs
@@ -1127,6 +1127,35 @@ mod tests {
     }
 
     #[test]
+    fn visible_input_views_equal_to_threshold_shows_all() {
+        let inputs: Vec<InputInfo> = (0..5)
+            .map(|i| InputInfo {
+                index: i,
+                value: 1_000,
+                address: String::new(),
+            })
+            .collect();
+        let (views, has_more) = visible_input_views(&inputs, false, 5, "DASH");
+        assert_eq!(views.len(), 5);
+        assert!(!has_more);
+    }
+
+    #[test]
+    fn visible_output_views_equal_to_threshold_shows_all() {
+        let outputs: Vec<OutputInfo> = (0..5)
+            .map(|i| OutputInfo {
+                index: i,
+                value: 500,
+                address: String::new(),
+                role: OutputRole::Received,
+            })
+            .collect();
+        let (views, has_more) = visible_output_views(&outputs, false, 5, "DASH");
+        assert_eq!(views.len(), 5);
+        assert!(!has_more);
+    }
+
+    #[test]
     fn format_output_all_roles() {
         let make = |role| OutputInfo {
             index: 0,

--- a/src/state/view_models.rs
+++ b/src/state/view_models.rs
@@ -381,6 +381,57 @@ pub fn format_output(output: &OutputInfo, unit: &str) -> OutputView {
     }
 }
 
+/// The number of inputs/outputs shown before a "Show all" toggle appears.
+pub const COLLAPSE_THRESHOLD: usize = 5;
+
+/// Return the visible input views and whether more are hidden.
+///
+/// When `expanded` is false and the input count exceeds `threshold`, only
+/// the first `threshold` inputs are included and `has_more` is `true`.
+pub fn visible_input_views(
+    inputs: &[InputInfo],
+    expanded: bool,
+    threshold: usize,
+    unit: &str,
+) -> (Vec<InputView>, bool) {
+    let has_more = inputs.len() > threshold;
+    let count = if expanded || !has_more {
+        inputs.len()
+    } else {
+        threshold
+    };
+    let views = inputs
+        .iter()
+        .take(count)
+        .map(|i| format_input(i, unit))
+        .collect();
+    (views, has_more)
+}
+
+/// Return the visible output views and whether more are hidden.
+///
+/// When `expanded` is false and the output count exceeds `threshold`, only
+/// the first `threshold` outputs are included and `has_more` is `true`.
+pub fn visible_output_views(
+    outputs: &[OutputInfo],
+    expanded: bool,
+    threshold: usize,
+    unit: &str,
+) -> (Vec<OutputView>, bool) {
+    let has_more = outputs.len() > threshold;
+    let count = if expanded || !has_more {
+        outputs.len()
+    } else {
+        threshold
+    };
+    let views = outputs
+        .iter()
+        .take(count)
+        .map(|o| format_output(o, unit))
+        .collect();
+    (views, has_more)
+}
+
 /// Map an `OutputRole` to a human-readable label and Tailwind color class.
 fn role_display(role: OutputRole) -> (&'static str, &'static str) {
     match role {
@@ -986,6 +1037,78 @@ mod tests {
         assert_eq!(view.amount_display, "1.0 DASH");
         assert_eq!(view.role_label, "Received");
         assert_eq!(view.role_color, "bg-success");
+    }
+
+    #[test]
+    fn visible_input_views_all_shown_when_under_threshold() {
+        let inputs: Vec<InputInfo> = (0..3)
+            .map(|i| InputInfo {
+                index: i,
+                value: 1_000,
+                address: String::new(),
+            })
+            .collect();
+        let (views, has_more) = visible_input_views(&inputs, false, 5, "DASH");
+        assert_eq!(views.len(), 3);
+        assert!(!has_more);
+    }
+
+    #[test]
+    fn visible_input_views_truncated_when_collapsed() {
+        let inputs: Vec<InputInfo> = (0..8)
+            .map(|i| InputInfo {
+                index: i,
+                value: 1_000,
+                address: String::new(),
+            })
+            .collect();
+        let (views, has_more) = visible_input_views(&inputs, false, 5, "DASH");
+        assert_eq!(views.len(), 5);
+        assert!(has_more);
+    }
+
+    #[test]
+    fn visible_input_views_all_shown_when_expanded() {
+        let inputs: Vec<InputInfo> = (0..8)
+            .map(|i| InputInfo {
+                index: i,
+                value: 1_000,
+                address: String::new(),
+            })
+            .collect();
+        let (views, has_more) = visible_input_views(&inputs, true, 5, "DASH");
+        assert_eq!(views.len(), 8);
+        assert!(has_more);
+    }
+
+    #[test]
+    fn visible_output_views_truncated_when_collapsed() {
+        let outputs: Vec<OutputInfo> = (0..7)
+            .map(|i| OutputInfo {
+                index: i,
+                value: 500,
+                address: String::new(),
+                role: OutputRole::Received,
+            })
+            .collect();
+        let (views, has_more) = visible_output_views(&outputs, false, 5, "DASH");
+        assert_eq!(views.len(), 5);
+        assert!(has_more);
+    }
+
+    #[test]
+    fn visible_output_views_all_shown_when_expanded() {
+        let outputs: Vec<OutputInfo> = (0..7)
+            .map(|i| OutputInfo {
+                index: i,
+                value: 500,
+                address: String::new(),
+                role: OutputRole::Received,
+            })
+            .collect();
+        let (views, has_more) = visible_output_views(&outputs, true, 5, "DASH");
+        assert_eq!(views.len(), 7);
+        assert!(has_more);
     }
 
     #[test]

--- a/src/state/view_models.rs
+++ b/src/state/view_models.rs
@@ -1082,6 +1082,21 @@ mod tests {
     }
 
     #[test]
+    fn visible_output_views_all_shown_when_under_threshold() {
+        let outputs: Vec<OutputInfo> = (0..3)
+            .map(|i| OutputInfo {
+                index: i,
+                value: 500,
+                address: String::new(),
+                role: OutputRole::Received,
+            })
+            .collect();
+        let (views, has_more) = visible_output_views(&outputs, false, 5, "DASH");
+        assert_eq!(views.len(), 3);
+        assert!(!has_more);
+    }
+
+    #[test]
     fn visible_output_views_truncated_when_collapsed() {
         let outputs: Vec<OutputInfo> = (0..7)
             .map(|i| OutputInfo {

--- a/src/state/wallet.rs
+++ b/src/state/wallet.rs
@@ -621,7 +621,13 @@ mod tests {
         let tx = &state.transactions[0];
         assert_eq!(tx.height, Some(4000));
         assert!(tx.is_chain_locked);
-        assert_eq!(tx.inputs, inputs, "inputs must be preserved after status update");
-        assert_eq!(tx.outputs, outputs, "outputs must be preserved after status update");
+        assert_eq!(
+            tx.inputs, inputs,
+            "inputs must be preserved after status update"
+        );
+        assert_eq!(
+            tx.outputs, outputs,
+            "outputs must be preserved after status update"
+        );
     }
 }

--- a/src/state/wallet.rs
+++ b/src/state/wallet.rs
@@ -50,6 +50,12 @@ impl WalletState {
                         existing.addresses.clone_from(&info.addresses);
                         existing.label.clone_from(&info.label);
                     }
+                    if !info.inputs.is_empty() {
+                        existing.inputs.clone_from(&info.inputs);
+                    }
+                    if !info.outputs.is_empty() {
+                        existing.outputs.clone_from(&info.outputs);
+                    }
                     sort_transactions(&mut self.transactions);
                     return;
                 }
@@ -571,5 +577,51 @@ mod tests {
             state.transactions[0].label,
             Some("payment for coffee".into())
         );
+    }
+
+    #[test]
+    fn status_update_preserves_inputs_and_outputs() {
+        use crate::backend::types::{InputInfo, OutputInfo, OutputRole};
+
+        let mut state = WalletState::default();
+
+        let inputs = vec![InputInfo {
+            index: 0,
+            value: 100_000,
+            address: "Xinput1".into(),
+        }];
+        let outputs = vec![OutputInfo {
+            index: 0,
+            value: 99_774,
+            address: "Xout1".into(),
+            role: OutputRole::Received,
+        }];
+
+        state.apply_event(&SpvEvent::TransactionReceived(Box::new(TransactionInfo {
+            txid: dashcore::Txid::from_byte_array([9u8; 32]),
+            amount: 99_774,
+            direction: TransactionDirection::Incoming,
+            transaction_type: TransactionType::Standard,
+            timestamp: 1700000000,
+            height: None,
+            fee: None,
+            addresses: vec!["Xout1".into()],
+            block_hash: None,
+            is_instant_send: false,
+            is_chain_locked: false,
+            label: None,
+            inputs: inputs.clone(),
+            outputs: outputs.clone(),
+        })));
+
+        // Status-only update: inputs/outputs are empty (as emitted by TransactionStatusChanged)
+        state.apply_event(&status_event(9, Some(4000), 1700001000, false, true));
+
+        assert_eq!(state.transactions.len(), 1);
+        let tx = &state.transactions[0];
+        assert_eq!(tx.height, Some(4000));
+        assert!(tx.is_chain_locked);
+        assert_eq!(tx.inputs, inputs, "inputs must be preserved after status update");
+        assert_eq!(tx.outputs, outputs, "outputs must be preserved after status update");
     }
 }

--- a/src/state/wallet.rs
+++ b/src/state/wallet.rs
@@ -97,6 +97,8 @@ mod tests {
             is_instant_send: false,
             is_chain_locked: false,
             label: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         }))
     }
 
@@ -120,6 +122,8 @@ mod tests {
             is_instant_send,
             is_chain_locked,
             label: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         }))
     }
 
@@ -194,6 +198,8 @@ mod tests {
             is_instant_send: false,
             is_chain_locked: true,
             label: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         }));
         state.apply_event(&event);
 
@@ -222,6 +228,8 @@ mod tests {
             is_instant_send: true,
             is_chain_locked: false,
             label: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         })));
 
         assert_eq!(state.transactions.len(), 1);
@@ -279,6 +287,8 @@ mod tests {
             is_instant_send: false,
             is_chain_locked: false,
             label: Some("my mix".into()),
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         })));
 
         // Status update with hardcoded Incoming/Standard fallbacks (amount=0)
@@ -333,6 +343,8 @@ mod tests {
                 is_instant_send: false,
                 is_chain_locked: false,
                 label: None,
+                inputs: Vec::new(),
+                outputs: Vec::new(),
             },
             TransactionInfo {
                 txid: dashcore::Txid::from_byte_array([2u8; 32]),
@@ -347,6 +359,8 @@ mod tests {
                 is_instant_send: false,
                 is_chain_locked: false,
                 label: None,
+                inputs: Vec::new(),
+                outputs: Vec::new(),
             },
         ];
         state.set_transactions(txs);
@@ -379,6 +393,8 @@ mod tests {
                 is_instant_send: false,
                 is_chain_locked: false,
                 label: None,
+                inputs: Vec::new(),
+                outputs: Vec::new(),
             },
             TransactionInfo {
                 txid: dashcore::Txid::from_byte_array([2u8; 32]),
@@ -393,6 +409,8 @@ mod tests {
                 is_instant_send: false,
                 is_chain_locked: false,
                 label: None,
+                inputs: Vec::new(),
+                outputs: Vec::new(),
             },
         ];
         state.set_transactions(txs);
@@ -450,6 +468,8 @@ mod tests {
                 is_instant_send: false,
                 is_chain_locked: false,
                 label: None,
+                inputs: Vec::new(),
+                outputs: Vec::new(),
             },
             TransactionInfo {
                 txid: dashcore::Txid::from_byte_array([2u8; 32]),
@@ -464,6 +484,8 @@ mod tests {
                 is_instant_send: false,
                 is_chain_locked: false,
                 label: None,
+                inputs: Vec::new(),
+                outputs: Vec::new(),
             },
         ];
         state.set_transactions(txs);
@@ -540,6 +562,8 @@ mod tests {
             is_instant_send: false,
             is_chain_locked: false,
             label: Some("payment for coffee".into()),
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         })));
 
         assert_eq!(state.transactions.len(), 1);


### PR DESCRIPTION
## Summary

- Add `InputInfo`, `OutputInfo`, and `OutputRole` types to `TransactionInfo`
- Populate inputs/outputs from upstream `TransactionRecord` in Native and FFI backends
- Add `InputView`/`OutputView` formatting in view model layer with role badges
- Show collapsible Inputs/Outputs sections in expanded transaction detail view
- Auto-collapse sections with >5 items, with "Show all" toggle

**Draft** — will rebase after #154 merges.

Closes #143