### PR TITLE
fix: prevent `AppConfig::save()` from clobbering production config from tests

### DIFF
--- a/src/components/layout.rs
+++ b/src/components/layout.rs
@@ -70,7 +70,7 @@ pub fn AppLayout() -> Element {
         let mut cfg = config.write();
         cfg.window_width = size.width;
         cfg.window_height = size.height;
-        let _ = cfg.save();
+        let _ = cfg.save(&AppConfig::default_config_path());
     });
 
     rsx! {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -714,6 +714,24 @@ mod tests {
     }
 
     #[test]
+    fn load_with_cli_first_run_writes_to_specified_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("nonexistent.toml");
+        assert!(!config_path.exists(), "precondition: path must not exist");
+
+        let cli = Cli::default();
+        let config = AppConfig::load_with_cli(cli, &config_path).unwrap();
+
+        assert!(
+            config_path.exists(),
+            "load_with_cli must write defaults to the given path"
+        );
+        let contents = std::fs::read_to_string(&config_path).unwrap();
+        let on_disk: AppConfig = toml::from_str(&contents).unwrap();
+        assert_eq!(on_disk.network, config.network);
+    }
+
+    #[test]
     fn config_error_implements_std_error() {
         let io_err = ConfigError::Io(io::Error::new(io::ErrorKind::PermissionDenied, "denied"));
         let std_err: &dyn std::error::Error = &io_err;

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -687,10 +687,8 @@ mod tests {
 
     #[test]
     fn save_writes_valid_toml() {
-        let tmp = std::env::temp_dir().join("dash-spv-ui-test-save");
-        let _ = std::fs::remove_dir_all(&tmp);
-        std::fs::create_dir_all(&tmp).unwrap();
-        let config_path = tmp.join("config.toml");
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("config.toml");
 
         let config = AppConfig {
             network: Network::Regtest,
@@ -713,8 +711,6 @@ mod tests {
         assert_eq!(restored.window_width, 800);
         assert_eq!(restored.window_height, 600);
         assert_eq!(restored.wallet_dir, Some(PathBuf::from("/tmp/wallets")));
-
-        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -281,7 +281,7 @@ impl AppConfig {
     }
 
     /// Save the current configuration to `path`.
-    pub fn save(&self, path: &Path) -> Result<(), ConfigError> {
+    pub(crate) fn save(&self, path: &Path) -> Result<(), ConfigError> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).map_err(ConfigError::Io)?;
         }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 use std::{fmt, fs, io};
 
@@ -218,6 +218,11 @@ impl AppConfig {
         Self::load_with_cli(Cli::parse(), &paths::config_file_path())
     }
 
+    /// Returns the default production config file path.
+    pub(crate) fn default_config_path() -> PathBuf {
+        paths::config_file_path()
+    }
+
     /// Load configuration from `config_path`, applying CLI overrides from `cli`.
     fn load_with_cli(cli: Cli, config_path: &std::path::Path) -> Result<Self, ConfigError> {
         let mut config = match fs::read_to_string(config_path) {
@@ -225,7 +230,7 @@ impl AppConfig {
                 .map_err(|e: toml::de::Error| ConfigError::Parse(e.to_string()))?,
             Err(e) if e.kind() == io::ErrorKind::NotFound => {
                 let default_config = Self::default();
-                let _ = default_config.save();
+                let _ = default_config.save(config_path);
                 default_config
             }
             Err(e) => return Err(ConfigError::Io(e)),
@@ -275,15 +280,14 @@ impl AppConfig {
         Ok(config)
     }
 
-    /// Save the current configuration to the TOML file.
-    pub fn save(&self) -> Result<(), ConfigError> {
-        let path = paths::config_file_path();
+    /// Save the current configuration to `path`.
+    pub fn save(&self, path: &Path) -> Result<(), ConfigError> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).map_err(ConfigError::Io)?;
         }
         let contents =
             toml::to_string_pretty(self).map_err(|e| ConfigError::Parse(e.to_string()))?;
-        fs::write(&path, contents).map_err(ConfigError::Io)
+        fs::write(path, contents).map_err(ConfigError::Io)
     }
 
     /// Returns the resolved wallet directory.
@@ -683,6 +687,11 @@ mod tests {
 
     #[test]
     fn save_writes_valid_toml() {
+        let tmp = std::env::temp_dir().join("dash-spv-ui-test-save");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        let config_path = tmp.join("config.toml");
+
         let config = AppConfig {
             network: Network::Regtest,
             data_dir: PathBuf::from("/tmp/data"),
@@ -694,16 +703,18 @@ mod tests {
             ..Default::default()
         };
 
-        config.save().unwrap();
+        config.save(&config_path).unwrap();
 
-        let path = paths::config_file_path();
-        let restored: AppConfig = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let restored: AppConfig =
+            toml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
         assert_eq!(restored.network, Network::Regtest);
         assert!(restored.dev_mode);
         assert_eq!(restored.log_level, "debug");
         assert_eq!(restored.window_width, 800);
         assert_eq!(restored.window_height, 600);
         assert_eq!(restored.wallet_dir, Some(PathBuf::from("/tmp/wallets")));
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]

--- a/src/screens/network_select.rs
+++ b/src/screens/network_select.rs
@@ -25,7 +25,7 @@ pub fn NetworkSelect() -> Element {
             app_state.write().select_network(network);
             let mut cfg = config.write();
             cfg.network = network;
-            let _ = cfg.save();
+            let _ = cfg.save(&AppConfig::default_config_path());
             navigator.push(Route::WalletChoice {});
         }
     };

--- a/src/screens/settings.rs
+++ b/src/screens/settings.rs
@@ -92,7 +92,7 @@ pub fn Settings() -> Element {
         cfg.log_level = log_level();
         cfg.network_config_mut().mempool_strategy = mempool_strategy();
 
-        match cfg.save() {
+        match cfg.save(&AppConfig::default_config_path()) {
             Ok(()) => save_status.set(Some(Ok(()))),
             Err(e) => save_status.set(Some(Err(e.to_string()))),
         }


### PR DESCRIPTION
## Summary

- `AppConfig::save()` now requires an explicit `&Path` argument — the default-path convenience method is gone, so tests physically cannot reach `paths::config_file_path()` without spelling it out.
- Production callers (`load_with_cli` first-run writeback, settings screen, network-select onboarding, window-close persistence in `AppLayout`) pass `AppConfig::default_config_path()` (a small `pub(crate)` accessor that returns `paths::config_file_path()`).
- `save_writes_valid_toml` now writes to and reads from a temp directory.

Previously the test clobbered the developer's real `~/Library/Application Support/dash-spv-ui/config.toml` with `network = "regtest"`, `data_dir = "/tmp/data"`, `wallet_dir = "/tmp/wallets"`, `dev_mode = true` on every `cargo test` run, which presented as a silent network revert and a "wallet is gone" splash screen on next app launch.

Verified by snapshotting the real config file, running `cargo test --lib`, and diffing — zero bytes changed.

Closes #161