### PR TITLE
chore: upgrade rust-dashcore to latest v0.42-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -84,7 +84,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -796,12 +796,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,26 +976,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "dash-network"
+version = "0.42.0"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
+dependencies = [
+ "bincode",
+ "bincode_derive",
+ "cbindgen",
+ "serde",
+]
+
+[[package]]
+name = "dash-network-seeds"
+version = "0.42.0"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
+dependencies = [
+ "dash-network",
+]
+
+[[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
 dependencies = [
- "anyhow",
  "async-trait",
- "bincode",
- "blsful",
  "chrono",
  "clap",
+ "dash-network-seeds",
  "dashcore",
  "dashcore-rpc",
  "dashcore_hashes",
  "futures",
  "hex",
- "hickory-resolver",
- "indexmap 2.13.1",
  "key-wallet",
  "key-wallet-manager",
- "log",
  "rand 0.8.5",
  "rayon",
  "serde",
@@ -1019,23 +1027,17 @@ dependencies = [
 [[package]]
 name = "dash-spv-ffi"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
 dependencies = [
  "cbindgen",
  "clap",
+ "dash-network",
  "dash-spv",
  "dashcore",
- "env_logger",
  "hex",
  "key-wallet",
  "key-wallet-ffi",
  "key-wallet-manager",
- "libc",
- "log",
- "once_cell",
- "rand 0.8.5",
- "serde",
- "serde_json",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1046,6 +1048,7 @@ name = "dash-spv-wallet"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "dash-network",
  "dash-spv",
  "dash-spv-ffi",
  "dashcore",
@@ -1068,7 +1071,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1078,40 +1081,41 @@ dependencies = [
  "bitvec",
  "blake3",
  "blsful",
+ "dash-network",
  "dashcore-private",
  "dashcore_hashes",
  "ed25519-dalek",
  "hex",
  "hex_lit",
- "log",
  "rustversion",
  "secp256k1",
  "serde",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "dashcore-private"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
  "jsonrpc",
- "log",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1126,12 +1130,11 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
 dependencies = [
  "bincode",
  "dashcore-private",
  "rs-x11-hash",
- "secp256k1",
  "serde",
 ]
 
@@ -1648,7 +1651,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1791,18 +1794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "enumset"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,19 +1815,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,7 +1827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2552,52 +2530,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand 0.9.2",
- "ring",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto",
- "ipconfig",
- "moka",
- "once_cell",
- "parking_lot",
- "rand 0.9.2",
- "resolv-conf",
- "smallvec",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,12 +2576,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2661,7 +2587,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2830,36 +2756,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipconfig"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
-dependencies = [
- "socket2",
- "widestring",
- "windows-registry",
- "windows-result 0.4.1",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "ipnet"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3003,7 +2899,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
 dependencies = [
  "aes",
  "async-trait",
@@ -3031,9 +2927,10 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
 dependencies = [
  "cbindgen",
+ "dash-network",
  "dashcore",
  "hex",
  "key-wallet",
@@ -3046,7 +2943,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#20983fa8edd7d61dd01a77c68735ebe8ea145db1"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3054,6 +2951,7 @@ dependencies = [
  "key-wallet",
  "rayon",
  "tokio",
+ "tracing",
  "zeroize",
 ]
 
@@ -3386,23 +3284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "moka"
-version = "0.12.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-epoch",
- "crossbeam-utils",
- "equivalent",
- "parking_lot",
- "portable-atomic",
- "smallvec",
- "tagptr",
- "uuid",
-]
-
-[[package]]
 name = "muda"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3502,7 +3383,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3741,10 +3622,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4055,12 +3932,6 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -4381,18 +4252,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4408,12 +4267,6 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "resolv-conf"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfd"
@@ -4492,7 +4345,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4978,7 +4831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5152,12 +5005,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tagptr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
-
-[[package]]
 name = "tao"
 version = "0.34.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5191,7 +5038,7 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]
@@ -5229,7 +5076,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5241,15 +5088,6 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -5739,7 +5577,6 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -6035,7 +5872,7 @@ dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-implement",
  "windows-interface",
 ]
@@ -6059,14 +5896,8 @@ checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -6090,7 +5921,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6106,7 +5937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6118,7 +5949,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6130,21 +5961,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6153,7 +5971,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6198,19 +6016,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6223,30 +6030,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6658,7 +6447,7 @@ dependencies = [
  "webkit2gtk-sys",
  "webview2-com",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,12 @@ path = "src/main.rs"
 [dependencies]
 dashcore = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev", features = ["serde"] }
 dash-spv = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev", features = ["keep-finalized-transactions"] }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev", features = ["keep-finalized-transactions"] }
 
 dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev", optional = true }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev", optional = true }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev", optional = true, features = ["keep-finalized-transactions"] }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev", features = ["ffi"], optional = true }
 
 dioxus = { version = "0.7", features = ["desktop", "router"] }
 clap = { version = "4", features = ["derive"] }
@@ -35,7 +36,7 @@ toml = "0.8"
 tracing = "0.1"
 
 [features]
-ffi = ["dep:dash-spv-ffi", "dep:key-wallet-ffi"]
+ffi = ["dep:dash-spv-ffi", "dep:key-wallet-ffi", "dep:dash-network"]
 
 [dev-dependencies]
 dash-spv = { git = "https://github.com/dashpay/rust-dashcore", branch = "v0.42-dev", features = ["test-utils"] }
@@ -51,6 +52,7 @@ key-wallet = { git = "https://github.com/xdustinface/rust-dashcore", branch = "f
 key-wallet-manager = { git = "https://github.com/xdustinface/rust-dashcore", branch = "feat/dash-spv-wallet" }
 dash-spv-ffi = { git = "https://github.com/xdustinface/rust-dashcore", branch = "feat/dash-spv-wallet" }
 key-wallet-ffi = { git = "https://github.com/xdustinface/rust-dashcore", branch = "feat/dash-spv-wallet" }
+dash-network = { git = "https://github.com/xdustinface/rust-dashcore", branch = "feat/dash-spv-wallet" }
 
 # Use patched version with Windows support (crates.io 0.1.8 lacks unistd.h handling)
 [patch.crates-io]

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1916,6 +1916,23 @@ mod tests {
         }
     }
 
+    /// Reset borrowed pointer fields on a test-built record before drop.
+    ///
+    /// `FFITransactionRecord::Drop` calls `Box::from_raw` on `input_details`,
+    /// `output_details`, `tx_data`, and `label` whenever they are non-null and
+    /// the matching length is non-zero. Tests build the record with stack or
+    /// borrowed pointers, so we null them out before the record drops to keep
+    /// Drop a no-op.
+    fn clear_borrowed_pointers(record: &mut FFITransactionRecord) {
+        record.input_details = ptr::null_mut();
+        record.input_details_count = 0;
+        record.output_details = ptr::null_mut();
+        record.output_details_count = 0;
+        record.tx_data = ptr::null_mut();
+        record.tx_len = 0;
+        record.label = ptr::null_mut();
+    }
+
     #[test]
     fn extract_ffi_inputs_null_pointer_returns_empty() {
         let record = empty_record();
@@ -1940,6 +1957,9 @@ mod tests {
         assert_eq!(result[0].index, 2);
         assert_eq!(result[0].value, 150_000_000);
         assert_eq!(result[0].address, "XqN8a73jYfHtFbEjz2XYBfrCHn6YQwBGsP");
+
+        clear_borrowed_pointers(&mut record);
+        detail.address = ptr::null_mut();
     }
 
     #[test]
@@ -1956,6 +1976,8 @@ mod tests {
         let result = extract_ffi_inputs(&record);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].address, "");
+
+        clear_borrowed_pointers(&mut record);
     }
 
     #[test]
@@ -1971,6 +1993,8 @@ mod tests {
 
         let result = extract_ffi_inputs(&record);
         assert!(result.is_empty());
+
+        clear_borrowed_pointers(&mut record);
     }
 
     #[test]
@@ -1982,6 +2006,8 @@ mod tests {
 
         let result = extract_ffi_outputs(&record, Network::Mainnet);
         assert!(result.is_empty());
+
+        clear_borrowed_pointers(&mut record);
     }
 
     #[test]
@@ -2006,6 +2032,8 @@ mod tests {
         assert_eq!(result[0].value, 0);
         assert_eq!(result[0].address, "");
         assert_eq!(result[0].role, OutputRole::Received);
+
+        clear_borrowed_pointers(&mut record);
     }
 
     #[test]
@@ -2022,6 +2050,8 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].value, 0);
         assert_eq!(result[0].address, "");
+
+        clear_borrowed_pointers(&mut record);
     }
 
     #[test]
@@ -2055,6 +2085,8 @@ mod tests {
         assert_eq!(result[1].index, 1);
         assert_eq!(result[1].value, 226);
         assert_eq!(result[1].role, OutputRole::Change);
+
+        clear_borrowed_pointers(&mut record);
     }
 
     #[test]

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1602,6 +1602,14 @@ extern "C" fn on_wallet_block_processed(
         if ptr.is_null() || count == 0 {
             return;
         }
+        if count as usize > MAX_DETAIL_COUNT {
+            tracing::warn!(
+                count,
+                max = MAX_DETAIL_COUNT,
+                "FFI record count exceeds safety bound, ignoring"
+            );
+            return;
+        }
         // Safety: ptr is valid for `count` elements for the duration of the callback.
         let records = unsafe { std::slice::from_raw_parts(ptr, count as usize) };
         for r in records {
@@ -1866,7 +1874,7 @@ mod tests {
     use dashcore::{Address, Transaction};
     use key_wallet_ffi::managed_account::FFIAccountType;
     use key_wallet_ffi::types::{
-        FFIBlockInfo, FFIInputDetail, FFIOutputDetail, FFITransactionContext,
+        FFIBalance, FFIBlockInfo, FFIInputDetail, FFIOutputDetail, FFITransactionContext,
         FFITransactionContextType, FFITransactionDirection, FFITransactionType,
     };
 
@@ -1953,13 +1961,13 @@ mod tests {
         record.input_details_count = 1;
 
         let result = extract_ffi_inputs(&record);
+        clear_borrowed_pointers(&mut record);
+        detail.address = ptr::null_mut();
+
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].index, 2);
         assert_eq!(result[0].value, 150_000_000);
         assert_eq!(result[0].address, "XqN8a73jYfHtFbEjz2XYBfrCHn6YQwBGsP");
-
-        clear_borrowed_pointers(&mut record);
-        detail.address = ptr::null_mut();
     }
 
     #[test]
@@ -1974,10 +1982,10 @@ mod tests {
         record.input_details_count = 1;
 
         let result = extract_ffi_inputs(&record);
+        clear_borrowed_pointers(&mut record);
+
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].address, "");
-
-        clear_borrowed_pointers(&mut record);
     }
 
     #[test]
@@ -1992,9 +2000,9 @@ mod tests {
         record.input_details_count = MAX_DETAIL_COUNT + 1;
 
         let result = extract_ffi_inputs(&record);
-        assert!(result.is_empty());
-
         clear_borrowed_pointers(&mut record);
+
+        assert!(result.is_empty());
     }
 
     #[test]
@@ -2005,9 +2013,9 @@ mod tests {
         record.output_details_count = MAX_DETAIL_COUNT + 1;
 
         let result = extract_ffi_outputs(&record, Network::Mainnet);
-        assert!(result.is_empty());
-
         clear_borrowed_pointers(&mut record);
+
+        assert!(result.is_empty());
     }
 
     #[test]
@@ -2028,12 +2036,12 @@ mod tests {
         record.tx_len = garbage.len();
 
         let result = extract_ffi_outputs(&record, Network::Mainnet);
+        clear_borrowed_pointers(&mut record);
+
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].value, 0);
         assert_eq!(result[0].address, "");
         assert_eq!(result[0].role, OutputRole::Received);
-
-        clear_borrowed_pointers(&mut record);
     }
 
     #[test]
@@ -2047,11 +2055,11 @@ mod tests {
         record.tx_len = 2_000_000;
 
         let result = extract_ffi_outputs(&record, Network::Mainnet);
+        clear_borrowed_pointers(&mut record);
+
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].value, 0);
         assert_eq!(result[0].address, "");
-
-        clear_borrowed_pointers(&mut record);
     }
 
     #[test]
@@ -2077,6 +2085,8 @@ mod tests {
         record.tx_len = tx_bytes.len();
 
         let result = extract_ffi_outputs(&record, Network::Testnet);
+        clear_borrowed_pointers(&mut record);
+
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].index, 0);
         assert_eq!(result[0].value, 99_774);
@@ -2085,8 +2095,6 @@ mod tests {
         assert_eq!(result[1].index, 1);
         assert_eq!(result[1].value, 226);
         assert_eq!(result[1].role, OutputRole::Change);
-
-        clear_borrowed_pointers(&mut record);
     }
 
     #[test]
@@ -2151,6 +2159,155 @@ mod tests {
             ffi_type_to_type(FFITransactionType::Ignored),
             TransactionType::Ignored,
         );
+    }
+
+    #[test]
+    fn on_wallet_block_processed_emits_records_then_balance() {
+        let (tx, mut rx) = super::super::events::event_channel(32);
+        let ctx = CallbackContext {
+            event_tx: tx,
+            progress: std::sync::Arc::new(std::sync::RwLock::new(SyncProgress::default())),
+            network: Network::Mainnet,
+        };
+        let user_data = &ctx as *const CallbackContext as *mut c_void;
+
+        let mut r1 = empty_record();
+        r1.net_amount = 10_000;
+        let mut r2 = empty_record();
+        r2.net_amount = 20_000;
+        let balance = FFIBalance {
+            confirmed: 30_000,
+            unconfirmed: 0,
+            immature: 0,
+            locked: 0,
+            total: 30_000,
+        };
+
+        unsafe {
+            on_wallet_block_processed(
+                ptr::null(),
+                100,
+                &r1 as *const _,
+                1,
+                &r2 as *const _,
+                1,
+                ptr::null(),
+                0,
+                &balance as *const _,
+                ptr::null(),
+                0,
+                ptr::null(),
+                0,
+                user_data,
+            );
+        }
+
+        let ev0 = rx.try_recv().unwrap();
+        let ev1 = rx.try_recv().unwrap();
+        let ev2 = rx.try_recv().unwrap();
+        assert!(rx.try_recv().is_err(), "expected exactly 3 events");
+
+        match ev0 {
+            SpvEvent::TransactionReceived(info) => assert_eq!(info.amount, 10_000),
+            other => panic!("expected TransactionReceived, got {:?}", other),
+        }
+        match ev1 {
+            SpvEvent::TransactionReceived(info) => assert_eq!(info.amount, 20_000),
+            other => panic!("expected TransactionReceived, got {:?}", other),
+        }
+        assert!(matches!(ev2, SpvEvent::BalanceUpdated(_)));
+    }
+
+    #[test]
+    fn on_wallet_block_processed_oversized_count_skips_records() {
+        let (tx, mut rx) = super::super::events::event_channel(32);
+        let ctx = CallbackContext {
+            event_tx: tx,
+            progress: std::sync::Arc::new(std::sync::RwLock::new(SyncProgress::default())),
+            network: Network::Mainnet,
+        };
+        let user_data = &ctx as *const CallbackContext as *mut c_void;
+
+        let record = empty_record();
+        let balance = FFIBalance {
+            confirmed: 1_000,
+            unconfirmed: 0,
+            immature: 0,
+            locked: 0,
+            total: 1_000,
+        };
+
+        unsafe {
+            on_wallet_block_processed(
+                ptr::null(),
+                1,
+                &record as *const _,
+                (MAX_DETAIL_COUNT as u32) + 1,
+                ptr::null(),
+                0,
+                ptr::null(),
+                0,
+                &balance as *const _,
+                ptr::null(),
+                0,
+                ptr::null(),
+                0,
+                user_data,
+            );
+        }
+
+        let ev = rx.try_recv().unwrap();
+        assert!(
+            matches!(ev, SpvEvent::BalanceUpdated(_)),
+            "oversized count must be skipped, only balance emitted"
+        );
+        assert!(rx.try_recv().is_err(), "expected exactly 1 event");
+    }
+
+    #[test]
+    fn ffi_record_to_info_mempool_uses_fallback_timestamp_and_no_height() {
+        let mut record = empty_record();
+        record.net_amount = 55_000;
+        record.direction = FFITransactionDirection::Incoming;
+        record.context.context_type = FFITransactionContextType::Mempool;
+
+        let info = ffi_record_to_info(&record, Network::Mainnet);
+
+        assert_eq!(info.amount, 55_000);
+        assert_eq!(info.height, None);
+        assert!(!info.is_instant_send);
+        assert!(!info.is_chain_locked);
+        assert!(info.timestamp > 0);
+    }
+
+    #[test]
+    fn ffi_record_to_info_instant_send_sets_flag() {
+        let mut record = empty_record();
+        record.context.context_type = FFITransactionContextType::InstantSend;
+
+        let info = ffi_record_to_info(&record, Network::Mainnet);
+
+        assert!(info.is_instant_send);
+        assert!(!info.is_chain_locked);
+        assert_eq!(info.height, None);
+    }
+
+    #[test]
+    fn ffi_record_to_info_in_block_uses_block_timestamp_and_height() {
+        let mut record = empty_record();
+        record.context.context_type = FFITransactionContextType::InBlock;
+        record.context.block_info = FFIBlockInfo {
+            height: 800,
+            block_hash: [1u8; 32],
+            timestamp: 1_700_000_000,
+        };
+
+        let info = ffi_record_to_info(&record, Network::Mainnet);
+
+        assert_eq!(info.height, Some(800));
+        assert_eq!(info.timestamp, 1_700_000_000);
+        assert!(!info.is_instant_send);
+        assert!(!info.is_chain_locked);
     }
 
     #[test]

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -2214,10 +2214,15 @@ mod tests {
         );
 
         let ev = rx.try_recv().unwrap();
-        assert!(
-            matches!(ev, SpvEvent::BalanceUpdated(_)),
-            "null record must emit only balance"
-        );
+        match ev {
+            SpvEvent::BalanceUpdated(b) => {
+                assert_eq!(b.confirmed(), 5_000, "confirmed");
+                assert_eq!(b.unconfirmed(), 0, "unconfirmed");
+                assert_eq!(b.immature(), 0, "immature");
+                assert_eq!(b.locked(), 0, "locked");
+            }
+            other => panic!("expected BalanceUpdated, got {:?}", other),
+        }
         assert!(rx.try_recv().is_err(), "expected exactly 1 event");
     }
 
@@ -2329,7 +2334,15 @@ mod tests {
             SpvEvent::TransactionReceived(info) => assert_eq!(info.amount, 20_000),
             other => panic!("expected TransactionReceived, got {:?}", other),
         }
-        assert!(matches!(ev2, SpvEvent::BalanceUpdated(_)));
+        match ev2 {
+            SpvEvent::BalanceUpdated(b) => {
+                assert_eq!(b.confirmed(), 30_000, "confirmed");
+                assert_eq!(b.unconfirmed(), 0, "unconfirmed");
+                assert_eq!(b.immature(), 0, "immature");
+                assert_eq!(b.locked(), 0, "locked");
+            }
+            other => panic!("expected BalanceUpdated, got {:?}", other),
+        }
     }
 
     #[test]
@@ -2481,5 +2494,103 @@ mod tests {
         let s = CString::new("coffee payment").unwrap();
         let result = unsafe { extract_ffi_label(s.as_ptr()) };
         assert_eq!(result, Some("coffee payment".to_string()));
+    }
+
+    #[test]
+    fn on_transaction_instant_locked_null_txid_emits_only_balance() {
+        let (tx, mut rx) = super::super::events::event_channel(32);
+        let ctx = CallbackContext {
+            event_tx: tx,
+            progress: std::sync::Arc::new(std::sync::RwLock::new(SyncProgress::default())),
+            network: Network::Mainnet,
+        };
+        let user_data = &ctx as *const CallbackContext as *mut c_void;
+        let balance = FFIBalance {
+            confirmed: 1_000,
+            unconfirmed: 200,
+            immature: 50,
+            locked: 0,
+            total: 1_250,
+        };
+
+        on_transaction_instant_locked(
+            ptr::null(),
+            ptr::null(),
+            ptr::null(),
+            0,
+            &balance as *const _,
+            ptr::null(),
+            0,
+            user_data,
+        );
+
+        let ev = rx.try_recv().unwrap();
+        match ev {
+            SpvEvent::BalanceUpdated(b) => {
+                assert_eq!(b.confirmed(), 1_000, "confirmed");
+                assert_eq!(b.unconfirmed(), 200, "unconfirmed");
+                assert_eq!(b.immature(), 50, "immature");
+                assert_eq!(b.locked(), 0, "locked");
+            }
+            other => panic!("expected BalanceUpdated, got {:?}", other),
+        }
+        assert!(rx.try_recv().is_err(), "expected exactly 1 event");
+    }
+
+    #[test]
+    fn on_transaction_instant_locked_non_null_txid_emits_received_with_is_instant_send() {
+        let (tx, mut rx) = super::super::events::event_channel(32);
+        let ctx = CallbackContext {
+            event_tx: tx,
+            progress: std::sync::Arc::new(std::sync::RwLock::new(SyncProgress::default())),
+            network: Network::Mainnet,
+        };
+        let user_data = &ctx as *const CallbackContext as *mut c_void;
+        let txid: [u8; 32] = [0xAB; 32];
+
+        on_transaction_instant_locked(
+            ptr::null(),
+            &txid as *const _,
+            ptr::null(),
+            0,
+            ptr::null(),
+            ptr::null(),
+            0,
+            user_data,
+        );
+
+        let ev = rx.try_recv().unwrap();
+        match ev {
+            SpvEvent::TransactionReceived(info) => {
+                assert!(info.is_instant_send);
+                assert_eq!(info.amount, 0);
+            }
+            other => panic!("expected TransactionReceived, got {:?}", other),
+        }
+        assert!(rx.try_recv().is_err(), "expected exactly 1 event");
+    }
+
+    #[test]
+    fn on_transaction_instant_locked_both_null_emits_nothing() {
+        let (tx, mut rx) = super::super::events::event_channel(32);
+        let ctx = CallbackContext {
+            event_tx: tx,
+            progress: std::sync::Arc::new(std::sync::RwLock::new(SyncProgress::default())),
+            network: Network::Mainnet,
+        };
+        let user_data = &ctx as *const CallbackContext as *mut c_void;
+
+        on_transaction_instant_locked(
+            ptr::null(),
+            ptr::null(),
+            ptr::null(),
+            0,
+            ptr::null(),
+            ptr::null(),
+            0,
+            user_data,
+        );
+
+        assert!(rx.try_recv().is_err(), "expected no events");
     }
 }

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -186,6 +186,8 @@ impl SpvBackend for FfiBackend {
             }
 
             if !peers.is_empty() {
+                // dash_spv_ffi_config_clear_peers was removed upstream; any default seed peers
+                // from config_new are not cleared before user peers are added.
                 for peer in &peers {
                     let c_peer = CString::new(peer.as_str())
                         .map_err(|e| BackendError::Internal(e.to_string()))?;
@@ -821,7 +823,7 @@ impl SpvBackend for FfiBackend {
                         is_confirmed: ffi_utxo.confirmations > 0,
                         is_instantlocked: false,
                         is_locked: false,
-                        is_trusted: false,
+                        is_trusted: ffi_utxo.confirmations > 0,
                     });
                 }
 
@@ -1559,7 +1561,7 @@ extern "C" fn on_transaction_detected(
 
 extern "C" fn on_transaction_instant_locked(
     _wallet_id: *const c_char,
-    _txid: *const [u8; 32],
+    txid: *const [u8; 32],
     _islock_data: *const u8,
     _islock_len: usize,
     balance: *const key_wallet_ffi::types::FFIBalance,
@@ -1569,6 +1571,28 @@ extern "C" fn on_transaction_instant_locked(
 ) {
     // Safety: user_data is a valid CallbackContext pointer (borrowed, not owned).
     let ctx = unsafe { &*(user_data as *const CallbackContext) };
+    if !txid.is_null() {
+        // Safety: txid is a valid pointer for the duration of the callback.
+        let txid_bytes = unsafe { *txid };
+        let _ = ctx
+            .event_tx
+            .send(SpvEvent::TransactionReceived(Box::new(TransactionInfo {
+                txid: dashcore::Txid::from_byte_array(txid_bytes),
+                is_instant_send: true,
+                amount: 0,
+                direction: TransactionDirection::Incoming,
+                transaction_type: TransactionType::Standard,
+                timestamp: 0,
+                height: None,
+                fee: None,
+                addresses: Vec::new(),
+                block_hash: None,
+                is_chain_locked: false,
+                label: None,
+                inputs: Vec::new(),
+                outputs: Vec::new(),
+            })));
+    }
     if !balance.is_null() {
         // Safety: balance is a valid pointer for the duration of the callback.
         let b = unsafe { &*balance };
@@ -2162,6 +2186,98 @@ mod tests {
     }
 
     #[test]
+    fn on_transaction_detected_null_record_emits_only_balance() {
+        let (tx, mut rx) = super::super::events::event_channel(32);
+        let ctx = CallbackContext {
+            event_tx: tx,
+            progress: std::sync::Arc::new(std::sync::RwLock::new(SyncProgress::default())),
+            network: Network::Mainnet,
+        };
+        let user_data = &ctx as *const CallbackContext as *mut c_void;
+        let balance = FFIBalance {
+            confirmed: 5_000,
+            unconfirmed: 0,
+            immature: 0,
+            locked: 0,
+            total: 5_000,
+        };
+
+        on_transaction_detected(
+            ptr::null(),
+            ptr::null(),
+            &balance as *const _,
+            ptr::null(),
+            0,
+            ptr::null(),
+            0,
+            user_data,
+        );
+
+        let ev = rx.try_recv().unwrap();
+        assert!(
+            matches!(ev, SpvEvent::BalanceUpdated(_)),
+            "null record must emit only balance"
+        );
+        assert!(rx.try_recv().is_err(), "expected exactly 1 event");
+    }
+
+    #[test]
+    fn on_transaction_detected_null_balance_emits_only_received() {
+        let (tx, mut rx) = super::super::events::event_channel(32);
+        let ctx = CallbackContext {
+            event_tx: tx,
+            progress: std::sync::Arc::new(std::sync::RwLock::new(SyncProgress::default())),
+            network: Network::Mainnet,
+        };
+        let user_data = &ctx as *const CallbackContext as *mut c_void;
+        let mut record = empty_record();
+        record.net_amount = 10_000;
+
+        on_transaction_detected(
+            ptr::null(),
+            &record as *const _,
+            ptr::null(),
+            ptr::null(),
+            0,
+            ptr::null(),
+            0,
+            user_data,
+        );
+        clear_borrowed_pointers(&mut record);
+
+        let ev = rx.try_recv().unwrap();
+        match ev {
+            SpvEvent::TransactionReceived(info) => assert_eq!(info.amount, 10_000),
+            other => panic!("expected TransactionReceived, got {:?}", other),
+        }
+        assert!(rx.try_recv().is_err(), "expected exactly 1 event");
+    }
+
+    #[test]
+    fn on_transaction_detected_both_null_emits_nothing() {
+        let (tx, mut rx) = super::super::events::event_channel(32);
+        let ctx = CallbackContext {
+            event_tx: tx,
+            progress: std::sync::Arc::new(std::sync::RwLock::new(SyncProgress::default())),
+            network: Network::Mainnet,
+        };
+        let user_data = &ctx as *const CallbackContext as *mut c_void;
+
+        on_transaction_detected(
+            ptr::null(),
+            ptr::null(),
+            ptr::null(),
+            ptr::null(),
+            0,
+            ptr::null(),
+            0,
+            user_data,
+        );
+
+        assert!(rx.try_recv().is_err(), "expected no events");
+    }
+
+    #[test]
     fn on_wallet_block_processed_emits_records_then_balance() {
         let (tx, mut rx) = super::super::events::event_channel(32);
         let ctx = CallbackContext {
@@ -2183,24 +2299,22 @@ mod tests {
             total: 30_000,
         };
 
-        unsafe {
-            on_wallet_block_processed(
-                ptr::null(),
-                100,
-                &r1 as *const _,
-                1,
-                &r2 as *const _,
-                1,
-                ptr::null(),
-                0,
-                &balance as *const _,
-                ptr::null(),
-                0,
-                ptr::null(),
-                0,
-                user_data,
-            );
-        }
+        on_wallet_block_processed(
+            ptr::null(),
+            100,
+            &r1 as *const _,
+            1,
+            &r2 as *const _,
+            1,
+            ptr::null(),
+            0,
+            &balance as *const _,
+            ptr::null(),
+            0,
+            ptr::null(),
+            0,
+            user_data,
+        );
 
         let ev0 = rx.try_recv().unwrap();
         let ev1 = rx.try_recv().unwrap();
@@ -2237,24 +2351,22 @@ mod tests {
             total: 1_000,
         };
 
-        unsafe {
-            on_wallet_block_processed(
-                ptr::null(),
-                1,
-                &record as *const _,
-                (MAX_DETAIL_COUNT as u32) + 1,
-                ptr::null(),
-                0,
-                ptr::null(),
-                0,
-                &balance as *const _,
-                ptr::null(),
-                0,
-                ptr::null(),
-                0,
-                user_data,
-            );
-        }
+        on_wallet_block_processed(
+            ptr::null(),
+            1,
+            &record as *const _,
+            (MAX_DETAIL_COUNT as u32) + 1,
+            ptr::null(),
+            0,
+            ptr::null(),
+            0,
+            &balance as *const _,
+            ptr::null(),
+            0,
+            ptr::null(),
+            0,
+            user_data,
+        );
 
         let ev = rx.try_recv().unwrap();
         assert!(

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -1467,7 +1467,6 @@ extern "C" fn on_peers_updated(connected_count: u32, best_height: u32, user_data
     });
 }
 
-/// Build a `TransactionInfo` from an `FFITransactionRecord`.
 fn ffi_record_to_info(r: &FFITransactionRecord, network: Network) -> TransactionInfo {
     let (is_instant_send, is_chain_locked) = ffi_transaction_context_flags(r.context.context_type);
 

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -2377,6 +2377,47 @@ mod tests {
     }
 
     #[test]
+    fn on_wallet_block_processed_null_balance_emits_only_records() {
+        let (tx, mut rx) = super::super::events::event_channel(32);
+        let ctx = CallbackContext {
+            event_tx: tx,
+            progress: std::sync::Arc::new(std::sync::RwLock::new(SyncProgress::default())),
+            network: Network::Mainnet,
+        };
+        let user_data = &ctx as *const CallbackContext as *mut c_void;
+
+        let mut r1 = empty_record();
+        r1.net_amount = 5_000;
+
+        on_wallet_block_processed(
+            ptr::null(),
+            1,
+            &r1 as *const _,
+            1,
+            ptr::null(),
+            0,
+            ptr::null(),
+            0,
+            ptr::null(),
+            ptr::null(),
+            0,
+            ptr::null(),
+            0,
+            user_data,
+        );
+
+        let ev = rx.try_recv().unwrap();
+        assert!(
+            matches!(ev, SpvEvent::TransactionReceived(_)),
+            "expected TransactionReceived"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "null balance must not emit BalanceUpdated"
+        );
+    }
+
+    #[test]
     fn ffi_record_to_info_mempool_uses_fallback_timestamp_and_no_height() {
         let mut record = empty_record();
         record.net_amount = 55_000;

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use dash_network::ffi::FFINetwork;
 use dash_spv::sync::{
     BlockHeadersProgress, BlocksProgress, ChainLockProgress, FilterHeadersProgress,
     FiltersProgress, InstantSendProgress, MasternodesProgress, MempoolProgress, SyncState,
@@ -21,9 +22,8 @@ use dash_spv_ffi::client::{
     dash_spv_ffi_client_stop, dash_spv_ffi_wallet_manager_free,
 };
 use dash_spv_ffi::config::{
-    dash_spv_ffi_config_add_peer, dash_spv_ffi_config_clear_peers, dash_spv_ffi_config_destroy,
-    dash_spv_ffi_config_new, dash_spv_ffi_config_set_data_dir,
-    dash_spv_ffi_config_set_masternode_sync_enabled,
+    dash_spv_ffi_config_add_peer, dash_spv_ffi_config_destroy, dash_spv_ffi_config_new,
+    dash_spv_ffi_config_set_data_dir, dash_spv_ffi_config_set_masternode_sync_enabled,
     dash_spv_ffi_config_set_restrict_to_configured_peers, dash_spv_ffi_config_set_user_agent,
 };
 use dash_spv_ffi::error::dash_spv_ffi_get_last_error;
@@ -34,6 +34,7 @@ use dash_spv_ffi::types::{
 };
 use dashcore::hashes::Hash;
 use key_wallet::DerivationPathBuilder;
+use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
 use key_wallet::managed_account::managed_account_type::ManagedAccountType;
 use key_wallet::wallet::initialization::WalletAccountCreationOptions;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
@@ -51,7 +52,7 @@ use key_wallet_ffi::managed_wallet::{
 };
 use key_wallet_ffi::mnemonic::{mnemonic_free, mnemonic_generate};
 use key_wallet_ffi::types::{
-    FFIAccountType, FFINetwork, FFIOutputRole, FFITransactionContextType, FFITransactionDirection,
+    FFIAccountKind, FFIOutputRole, FFITransactionContextType, FFITransactionDirection,
     FFITransactionType,
 };
 use key_wallet_ffi::utxo::{managed_wallet_get_utxos, utxo_array_free};
@@ -185,9 +186,6 @@ impl SpvBackend for FfiBackend {
             }
 
             if !peers.is_empty() {
-                // Safety: config_ptr is valid.
-                unsafe { dash_spv_ffi_config_clear_peers(config_ptr) };
-
                 for peer in &peers {
                     let c_peer = CString::new(peer.as_str())
                         .map_err(|e| BackendError::Internal(e.to_string()))?;
@@ -323,8 +321,9 @@ impl SpvBackend for FfiBackend {
     }
 
     fn generate_mnemonic(&self) -> BackendResult<String> {
-        let mut error = WalletFFIError::success();
-        let ptr = mnemonic_generate(12, &mut error);
+        let mut error = WalletFFIError::default();
+        // Safety: error is a valid stack pointer.
+        let ptr = unsafe { mnemonic_generate(12, &mut error) };
         if ptr.is_null() {
             return Err(BackendError::Internal(read_wallet_ffi_error(&error)));
         }
@@ -357,7 +356,7 @@ impl SpvBackend for FfiBackend {
                 return Err(BackendError::Internal(get_last_ffi_error()));
             }
 
-            let mut error = WalletFFIError::success();
+            let mut error = WalletFFIError::default();
 
             // Safety: wm is valid (just obtained), c_mnemonic is a valid C string,
             // passphrase is null (empty passphrase), error is a valid stack variable.
@@ -410,7 +409,7 @@ impl SpvBackend for FfiBackend {
                 return Err(BackendError::Internal(get_last_ffi_error()));
             }
 
-            let mut error = WalletFFIError::success();
+            let mut error = WalletFFIError::default();
 
             // Safety: wm is valid, c_mnemonic is a valid C string.
             let ok = unsafe {
@@ -464,7 +463,7 @@ impl SpvBackend for FfiBackend {
 
             let mut wallet_ids_ptr: *mut u8 = std::ptr::null_mut();
             let mut count: usize = 0;
-            let mut error = WalletFFIError::success();
+            let mut error = WalletFFIError::default();
 
             let ok = unsafe {
                 wallet_manager_get_wallet_ids(
@@ -489,7 +488,7 @@ impl SpvBackend for FfiBackend {
             // Now get the balance
             let mut confirmed: u64 = 0;
             let mut unconfirmed: u64 = 0;
-            error = WalletFFIError::success();
+            error = WalletFFIError::default();
 
             let ok = unsafe {
                 wallet_manager_get_wallet_balance(
@@ -532,7 +531,7 @@ impl SpvBackend for FfiBackend {
 
             let mut wallet_ids_ptr: *mut u8 = std::ptr::null_mut();
             let mut count: usize = 0;
-            let mut error = WalletFFIError::success();
+            let mut error = WalletFFIError::default();
 
             let ok = unsafe {
                 wallet_manager_get_wallet_ids(wm_typed, &mut wallet_ids_ptr, &mut count, &mut error)
@@ -555,7 +554,7 @@ impl SpvBackend for FfiBackend {
                     wm_typed,
                     wallet_id.as_ptr(),
                     0,
-                    FFIAccountType::StandardBIP44,
+                    FFIAccountKind::StandardBIP44,
                 )
             };
 
@@ -730,7 +729,7 @@ impl SpvBackend for FfiBackend {
             // Get wallet ID from FFI
             let mut wallet_ids_ptr: *mut u8 = std::ptr::null_mut();
             let mut count: usize = 0;
-            let mut error = WalletFFIError::success();
+            let mut error = WalletFFIError::default();
 
             let ok = unsafe {
                 wallet_manager_get_wallet_ids(wm_typed, &mut wallet_ids_ptr, &mut count, &mut error)
@@ -748,7 +747,7 @@ impl SpvBackend for FfiBackend {
             }
 
             // Get managed wallet info for UTXOs
-            error = WalletFFIError::success();
+            error = WalletFFIError::default();
             let managed_info = unsafe {
                 wallet_manager_get_managed_wallet_info(wm_typed, ffi_wallet_id.as_ptr(), &mut error)
             };
@@ -761,7 +760,7 @@ impl SpvBackend for FfiBackend {
             // Get UTXOs
             let mut utxos_ptr: *mut key_wallet_ffi::utxo::FFIUTXO = std::ptr::null_mut();
             let mut utxo_count: usize = 0;
-            error = WalletFFIError::success();
+            error = WalletFFIError::default();
 
             let ok = unsafe {
                 managed_wallet_get_utxos(managed_info, &mut utxos_ptr, &mut utxo_count, &mut error)
@@ -822,6 +821,7 @@ impl SpvBackend for FfiBackend {
                         is_confirmed: ffi_utxo.confirmations > 0,
                         is_instantlocked: false,
                         is_locked: false,
+                        is_trusted: false,
                     });
                 }
 
@@ -829,7 +829,7 @@ impl SpvBackend for FfiBackend {
             }
 
             // Get wallet for change address generation
-            error = WalletFFIError::success();
+            error = WalletFFIError::default();
             let ffi_wallet =
                 unsafe { wallet_manager_get_wallet(wm_typed, ffi_wallet_id.as_ptr(), &mut error) };
 
@@ -842,7 +842,7 @@ impl SpvBackend for FfiBackend {
             }
 
             // Get change address
-            error = WalletFFIError::success();
+            error = WalletFFIError::default();
             let change_addr_ptr = unsafe {
                 managed_wallet_get_next_bip44_change_address(
                     managed_info,
@@ -908,7 +908,7 @@ impl SpvBackend for FfiBackend {
                     external_addresses,
                     internal_addresses,
                     ..
-                } = &account.account_type
+                } = account.managed_account_type()
                 {
                     if let Some(addr_idx) = external_addresses.address_index(&utxo.address) {
                         let path = DerivationPathBuilder::new()
@@ -938,7 +938,7 @@ impl SpvBackend for FfiBackend {
                     external_addresses,
                     internal_addresses,
                     ..
-                } = &account.account_type
+                } = account.managed_account_type()
                 {
                     if let Some(addr_idx) = external_addresses.address_index(&utxo.address) {
                         let path = DerivationPathBuilder::new()
@@ -1275,9 +1275,10 @@ fn build_network_callbacks(user_data: *mut c_void) -> FFINetworkEventCallbacks {
 
 fn build_wallet_callbacks(user_data: *mut c_void) -> FFIWalletEventCallbacks {
     FFIWalletEventCallbacks {
-        on_transaction_received: Some(on_transaction_received),
-        on_transaction_status_changed: None,
-        on_balance_updated: Some(on_balance_updated),
+        on_transaction_detected: Some(on_transaction_detected),
+        on_transaction_instant_locked: Some(on_transaction_instant_locked),
+        on_block_processed: Some(on_wallet_block_processed),
+        on_sync_height_advanced: None,
         user_data,
     }
 }
@@ -1466,22 +1467,8 @@ extern "C" fn on_peers_updated(connected_count: u32, best_height: u32, user_data
     });
 }
 
-extern "C" fn on_transaction_received(
-    _wallet_id: *const c_char,
-    _account_index: u32,
-    record: *const FFITransactionRecord,
-    user_data: *mut c_void,
-) {
-    // Safety: user_data is a valid CallbackContext pointer (borrowed, not owned).
-    let ctx = unsafe { &*(user_data as *const CallbackContext) };
-
-    if record.is_null() {
-        return;
-    }
-
-    // Safety: record is a valid pointer to an FFITransactionRecord (callback contract).
-    let r = unsafe { &*record };
-
+/// Build a `TransactionInfo` from an `FFITransactionRecord`.
+fn ffi_record_to_info(r: &FFITransactionRecord, network: Network) -> TransactionInfo {
     let (is_instant_send, is_chain_locked) = ffi_transaction_context_flags(r.context.context_type);
 
     let block_info = &r.context.block_info;
@@ -1489,7 +1476,7 @@ extern "C" fn on_transaction_received(
 
     let addresses = extract_ffi_input_addresses(r);
     let inputs = extract_ffi_inputs(r);
-    let outputs = extract_ffi_outputs(r, ctx.network);
+    let outputs = extract_ffi_outputs(r, network);
 
     // Safety: label is a valid C string for the duration of the callback.
     let label = unsafe { extract_ffi_label(r.label) };
@@ -1499,56 +1486,146 @@ extern "C" fn on_transaction_received(
         .unwrap_or_default()
         .as_secs();
 
-    let _ = ctx
-        .event_tx
-        .send(SpvEvent::TransactionReceived(Box::new(TransactionInfo {
-            txid: dashcore::Txid::from_byte_array(r.txid),
-            amount: r.net_amount,
-            direction: ffi_direction_to_direction(r.direction),
-            transaction_type: ffi_type_to_type(r.transaction_type),
-            timestamp: if has_block {
-                block_info.timestamp as u64
-            } else {
-                fallback_timestamp
-            },
-            height: if has_block {
-                Some(block_info.height)
-            } else {
-                None
-            },
-            fee: if r.fee > 0 { Some(r.fee) } else { None },
-            addresses,
-            block_hash: if has_block {
-                Some(dashcore::BlockHash::from_byte_array(block_info.block_hash))
-            } else {
-                None
-            },
-            is_instant_send,
-            is_chain_locked,
-            label,
-            inputs,
-            outputs,
-        })));
+    TransactionInfo {
+        txid: dashcore::Txid::from_byte_array(r.txid),
+        amount: r.net_amount,
+        direction: ffi_direction_to_direction(r.direction),
+        transaction_type: ffi_type_to_type(r.transaction_type),
+        timestamp: if has_block {
+            block_info.timestamp as u64
+        } else {
+            fallback_timestamp
+        },
+        height: if has_block {
+            Some(block_info.height)
+        } else {
+            None
+        },
+        fee: if r.fee > 0 { Some(r.fee) } else { None },
+        addresses,
+        block_hash: if has_block {
+            Some(dashcore::BlockHash::from_byte_array(block_info.block_hash))
+        } else {
+            None
+        },
+        is_instant_send,
+        is_chain_locked,
+        label,
+        inputs,
+        outputs,
+    }
 }
 
-extern "C" fn on_balance_updated(
+fn ffi_balance_to_core(balance: &key_wallet_ffi::types::FFIBalance) -> WalletCoreBalance {
+    WalletCoreBalance::new(
+        balance.confirmed,
+        balance.unconfirmed,
+        balance.immature,
+        balance.locked,
+    )
+}
+
+extern "C" fn on_transaction_detected(
     _wallet_id: *const c_char,
-    spendable: u64,
-    unconfirmed: u64,
-    immature: u64,
-    locked: u64,
+    record: *const FFITransactionRecord,
+    balance: *const key_wallet_ffi::types::FFIBalance,
+    _account_balances: *const dash_spv_ffi::callbacks::FFIAccountBalance,
+    _account_balances_count: u32,
+    _addresses_derived: *const dash_spv_ffi::callbacks::FFIDerivedAddress,
+    _addresses_derived_count: u32,
     user_data: *mut c_void,
 ) {
     // Safety: user_data is a valid CallbackContext pointer (borrowed, not owned).
     let ctx = unsafe { &*(user_data as *const CallbackContext) };
-    let _ = ctx
-        .event_tx
-        .send(SpvEvent::BalanceUpdated(WalletCoreBalance::new(
-            spendable,
-            unconfirmed,
-            immature,
-            locked,
-        )));
+
+    if !record.is_null() {
+        // Safety: record is a valid pointer for the duration of the callback.
+        let r = unsafe { &*record };
+        let _ = ctx
+            .event_tx
+            .send(SpvEvent::TransactionReceived(Box::new(ffi_record_to_info(
+                r,
+                ctx.network,
+            ))));
+    }
+
+    if !balance.is_null() {
+        // Safety: balance is a valid pointer for the duration of the callback.
+        let b = unsafe { &*balance };
+        let _ = ctx
+            .event_tx
+            .send(SpvEvent::BalanceUpdated(ffi_balance_to_core(b)));
+    }
+}
+
+extern "C" fn on_transaction_instant_locked(
+    _wallet_id: *const c_char,
+    _txid: *const [u8; 32],
+    _islock_data: *const u8,
+    _islock_len: usize,
+    balance: *const key_wallet_ffi::types::FFIBalance,
+    _account_balances: *const dash_spv_ffi::callbacks::FFIAccountBalance,
+    _account_balances_count: u32,
+    user_data: *mut c_void,
+) {
+    // Safety: user_data is a valid CallbackContext pointer (borrowed, not owned).
+    let ctx = unsafe { &*(user_data as *const CallbackContext) };
+    if !balance.is_null() {
+        // Safety: balance is a valid pointer for the duration of the callback.
+        let b = unsafe { &*balance };
+        let _ = ctx
+            .event_tx
+            .send(SpvEvent::BalanceUpdated(ffi_balance_to_core(b)));
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+extern "C" fn on_wallet_block_processed(
+    _wallet_id: *const c_char,
+    _height: u32,
+    inserted: *const FFITransactionRecord,
+    inserted_count: u32,
+    updated: *const FFITransactionRecord,
+    updated_count: u32,
+    matured: *const FFITransactionRecord,
+    matured_count: u32,
+    balance: *const key_wallet_ffi::types::FFIBalance,
+    _account_balances: *const dash_spv_ffi::callbacks::FFIAccountBalance,
+    _account_balances_count: u32,
+    _addresses_derived: *const dash_spv_ffi::callbacks::FFIDerivedAddress,
+    _addresses_derived_count: u32,
+    user_data: *mut c_void,
+) {
+    // Safety: user_data is a valid CallbackContext pointer (borrowed, not owned).
+    let ctx = unsafe { &*(user_data as *const CallbackContext) };
+
+    let send_records = |ptr: *const FFITransactionRecord, count: u32| {
+        if ptr.is_null() || count == 0 {
+            return;
+        }
+        // Safety: ptr is valid for `count` elements for the duration of the callback.
+        let records = unsafe { std::slice::from_raw_parts(ptr, count as usize) };
+        for r in records {
+            let _ = ctx
+                .event_tx
+                .send(SpvEvent::TransactionReceived(Box::new(ffi_record_to_info(
+                    r,
+                    ctx.network,
+                ))));
+        }
+    };
+
+    send_records(inserted, inserted_count);
+    send_records(updated, updated_count);
+    send_records(matured, matured_count);
+
+    if !balance.is_null() {
+        // Safety: balance is a valid pointer for the duration of the callback.
+        let b = unsafe { &*balance };
+        let _ = ctx
+            .event_tx
+            .send(SpvEvent::BalanceUpdated(ffi_balance_to_core(b)));
+    }
 }
 
 extern "C" fn on_progress_update(progress: *const FFISyncProgress, user_data: *mut c_void) {
@@ -1788,12 +1865,24 @@ mod tests {
     use dashcore::consensus::serialize;
     use dashcore::key::PublicKey;
     use dashcore::{Address, Transaction};
+    use key_wallet_ffi::managed_account::FFIAccountType;
     use key_wallet_ffi::types::{
         FFIBlockInfo, FFIInputDetail, FFIOutputDetail, FFITransactionContext,
         FFITransactionContextType, FFITransactionDirection, FFITransactionType,
     };
 
     use super::*;
+
+    fn empty_account_type() -> FFIAccountType {
+        FFIAccountType {
+            kind: FFIAccountKind::StandardBIP44,
+            index: 0,
+            index_secondary: -1,
+            identity_user: ptr::null(),
+            identity_friend: ptr::null(),
+            key_class: -1,
+        }
+    }
 
     fn empty_record() -> FFITransactionRecord {
         FFITransactionRecord {
@@ -1808,6 +1897,7 @@ mod tests {
             transaction_type: FFITransactionType::Standard,
             direction: FFITransactionDirection::Incoming,
             fee: 0,
+            account_type: empty_account_type(),
             input_details: ptr::null_mut(),
             input_details_count: 0,
             output_details: ptr::null_mut(),
@@ -1815,6 +1905,15 @@ mod tests {
             tx_data: ptr::null_mut(),
             tx_len: 0,
             label: ptr::null_mut(),
+        }
+    }
+
+    fn empty_output_detail(index: u32, role: FFIOutputRole) -> FFIOutputDetail {
+        FFIOutputDetail {
+            index,
+            role,
+            value: 0,
+            address: ptr::null_mut(),
         }
     }
 
@@ -1877,10 +1976,7 @@ mod tests {
 
     #[test]
     fn extract_ffi_outputs_oversized_count_skips_extraction() {
-        let mut detail = FFIOutputDetail {
-            index: 0,
-            role: FFIOutputRole::Received,
-        };
+        let mut detail = empty_output_detail(0, FFIOutputRole::Received);
         let mut record = empty_record();
         record.output_details = &mut detail as *mut _;
         record.output_details_count = MAX_DETAIL_COUNT + 1;
@@ -1899,10 +1995,7 @@ mod tests {
     #[test]
     fn extract_ffi_outputs_bad_tx_data_falls_back_to_zero_value_empty_address() {
         let garbage: Vec<u8> = vec![0xDE, 0xAD, 0xBE, 0xEF];
-        let mut detail = FFIOutputDetail {
-            index: 0,
-            role: FFIOutputRole::Received,
-        };
+        let mut detail = empty_output_detail(0, FFIOutputRole::Received);
         let mut record = empty_record();
         record.output_details = &mut detail as *mut _;
         record.output_details_count = 1;
@@ -1918,10 +2011,7 @@ mod tests {
 
     #[test]
     fn extract_ffi_outputs_oversized_tx_len_skips_enrichment() {
-        let mut detail = FFIOutputDetail {
-            index: 0,
-            role: FFIOutputRole::Change,
-        };
+        let mut detail = empty_output_detail(0, FFIOutputRole::Change);
         let dummy_byte: u8 = 0;
         let mut record = empty_record();
         record.output_details = &mut detail as *mut _;
@@ -1948,14 +2038,8 @@ mod tests {
         let tx_bytes = serialize(&tx);
 
         let mut details = [
-            FFIOutputDetail {
-                index: 0,
-                role: FFIOutputRole::Received,
-            },
-            FFIOutputDetail {
-                index: 1,
-                role: FFIOutputRole::Change,
-            },
+            empty_output_detail(0, FFIOutputRole::Received),
+            empty_output_detail(1, FFIOutputRole::Change),
         ];
         let mut record = empty_record();
         record.output_details = details.as_mut_ptr();

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -657,7 +657,7 @@ mod tests {
         let result = backend.get_balance().unwrap();
         assert_eq!(result, balance);
         assert_eq!(result.total(), 1_075_000);
-        assert_eq!(result.spendable(), 1_000_000);
+        assert_eq!(result.spendable(), 1_050_000);
     }
 
     #[tokio::test]

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -13,6 +13,7 @@ use dash_spv::storage::DiskStorageManager;
 use dash_spv::sync::SyncEvent;
 use dash_spv::{ClientConfig, DashSpvClient, MempoolStrategy};
 use dashcore::hashes::Hash;
+use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
 use key_wallet::managed_account::managed_account_type::ManagedAccountType;
 use key_wallet::managed_account::transaction_record::{
     OutputRole as UpstreamOutputRole, TransactionRecord,
@@ -36,17 +37,12 @@ use super::error::{BackendError, BackendResult};
 use super::events::{EventReceiver, EventSender, SpvEvent, event_channel};
 use super::r#trait::SpvBackend;
 use super::types::{
-    InputInfo, Network, OutputInfo, OutputRole, SyncProgress, TransactionDirection,
-    TransactionInfo, TransactionType, WalletCoreBalance,
+    InputInfo, Network, OutputInfo, OutputRole, SyncProgress, TransactionInfo, WalletCoreBalance,
 };
 use crate::config::AppConfig;
 
-type SpvClient = DashSpvClient<
-    WalletManager<ManagedWalletInfo>,
-    PeerNetworkManager,
-    DiskStorageManager,
-    NativeEventHandler,
->;
+type SpvClient =
+    DashSpvClient<WalletManager<ManagedWalletInfo>, PeerNetworkManager, DiskStorageManager>;
 
 /// Implements `EventHandler` to bridge SPV client events into the UI event channel.
 struct NativeEventHandler {
@@ -76,9 +72,9 @@ impl EventHandler for NativeEventHandler {
     }
 
     fn on_wallet_event(&self, event: &WalletEvent) {
-        let _ = self
-            .event_tx
-            .send(map_wallet_event(event.clone(), self.network));
+        for spv_event in map_wallet_event(event.clone(), self.network) {
+            let _ = self.event_tx.send(spv_event);
+        }
     }
 
     fn on_error(&self, error: &str) {
@@ -195,7 +191,7 @@ impl SpvBackend for NativeBackend {
                 network_manager,
                 storage_manager,
                 self.wallet.clone(),
-                event_handler,
+                vec![event_handler],
             )
             .await
             .map_err(|e| BackendError::Internal(e.to_string()))?,
@@ -337,12 +333,8 @@ impl SpvBackend for NativeBackend {
             .try_write()
             .map_err(|_| BackendError::Internal("wallet lock contention".to_string()))?;
 
-        let result = wallet
-            .get_receive_address(wallet_id, 0, AccountTypePreference::PreferBIP44, true)
-            .map_err(|e| BackendError::Internal(e.to_string()))?;
-
-        result
-            .address
+        wallet
+            .next_receive_address(wallet_id, 0, AccountTypePreference::BIP44, true)
             .map(|a| a.to_string())
             .ok_or_else(|| BackendError::Internal("no address generated".to_string()))
     }
@@ -428,12 +420,11 @@ impl SpvBackend for NativeBackend {
         }
 
         // Get a change address
-        let change_result = wallet_guard
-            .get_change_address(wallet_id, 0, AccountTypePreference::PreferBIP44, true)
-            .map_err(|e| BackendError::Internal(e.to_string()))?;
-        let change_address = change_result.address.ok_or_else(|| {
-            BackendError::Internal("failed to generate change address".to_string())
-        })?;
+        let change_address = wallet_guard
+            .next_change_address(wallet_id, 0, AccountTypePreference::BIP44, true)
+            .ok_or_else(|| {
+                BackendError::Internal("failed to generate change address".to_string())
+            })?;
 
         // Get wallet reference for key derivation
         let (wallet, info) = wallet_guard
@@ -452,7 +443,7 @@ impl SpvBackend for NativeBackend {
                     external_addresses,
                     internal_addresses,
                     ..
-                } = &account.account_type
+                } = account.managed_account_type()
                 {
                     // Check external (receive) addresses
                     if let Some(addr_idx) = external_addresses.address_index(&utxo.address) {
@@ -484,7 +475,7 @@ impl SpvBackend for NativeBackend {
                     external_addresses,
                     internal_addresses,
                     ..
-                } = &account.account_type
+                } = account.managed_account_type()
                 {
                     if let Some(addr_idx) = external_addresses.address_index(&utxo.address) {
                         let path = DerivationPathBuilder::new()
@@ -657,59 +648,40 @@ fn map_network_event(event: NetworkEvent) -> SpvEvent {
     }
 }
 
-fn map_wallet_event(event: WalletEvent, network: Network) -> SpvEvent {
+fn map_wallet_event(event: WalletEvent, network: Network) -> Vec<SpvEvent> {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
     match event {
-        WalletEvent::TransactionReceived {
-            wallet_id: _,
-            account_index: _,
-            record,
-        } => {
-            let fallback_timestamp = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
+        WalletEvent::TransactionDetected {
+            record, balance, ..
+        } => vec![
             SpvEvent::TransactionReceived(Box::new(TransactionInfo::from_record(
-                &record,
-                fallback_timestamp,
-                network,
-            )))
+                &record, now, network,
+            ))),
+            SpvEvent::BalanceUpdated(balance),
+        ],
+        WalletEvent::TransactionInstantLocked { balance, .. } => {
+            vec![SpvEvent::BalanceUpdated(balance)]
         }
-        WalletEvent::TransactionStatusChanged { txid, status, .. } => {
-            let (height, timestamp, block_hash, is_instant_send, is_chain_locked) =
-                extract_context_fields(&status);
-            let fallback_timestamp = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-            SpvEvent::TransactionReceived(Box::new(TransactionInfo {
-                txid,
-                amount: 0,
-                direction: TransactionDirection::Incoming,
-                transaction_type: TransactionType::Standard,
-                timestamp: timestamp.unwrap_or(fallback_timestamp),
-                height,
-                fee: None,
-                addresses: Vec::new(),
-                block_hash: block_hash.map(dashcore::BlockHash::from_byte_array),
-                is_instant_send,
-                is_chain_locked,
-                label: None,
-                inputs: Vec::new(),
-                outputs: Vec::new(),
-            }))
-        }
-        WalletEvent::BalanceUpdated {
-            spendable,
-            unconfirmed,
-            immature,
-            locked,
+        WalletEvent::BlockProcessed {
+            inserted,
+            updated,
+            matured,
+            balance,
             ..
-        } => SpvEvent::BalanceUpdated(WalletCoreBalance::new(
-            spendable,
-            unconfirmed,
-            immature,
-            locked,
-        )),
+        } => {
+            let mut events = Vec::with_capacity(inserted.len() + updated.len() + matured.len() + 1);
+            for record in inserted.iter().chain(updated.iter()).chain(matured.iter()) {
+                events.push(SpvEvent::TransactionReceived(Box::new(
+                    TransactionInfo::from_record(record, now, network),
+                )));
+            }
+            events.push(SpvEvent::BalanceUpdated(balance));
+            events
+        }
+        WalletEvent::SyncHeightAdvanced { .. } => Vec::new(),
     }
 }
 
@@ -738,7 +710,11 @@ impl TransactionInfo {
             block_hash: block_hash.map(dashcore::BlockHash::from_byte_array),
             is_instant_send,
             is_chain_locked,
-            label: record.label.clone(),
+            label: if record.label.is_empty() {
+                None
+            } else {
+                Some(record.label.clone())
+            },
             inputs,
             outputs,
         }
@@ -844,6 +820,7 @@ mod tests {
     use dashcore::ephemerealdata::instant_lock::InstantLock;
     use dashcore::hashes::Hash;
     use dashcore::{Address, BlockHash, PublicKey, Txid};
+    use key_wallet::account::{AccountType, StandardAccountType};
     use key_wallet::managed_account::transaction_record::{
         InputDetail, OutputDetail, OutputRole as UpstreamTestOutputRole, TransactionRecord,
     };
@@ -853,6 +830,33 @@ mod tests {
     use key_wallet_manager::WalletEvent;
 
     use super::*;
+    use crate::backend::types::TransactionDirection;
+
+    fn standard_account_type() -> AccountType {
+        AccountType::Standard {
+            index: 0,
+            standard_account_type: StandardAccountType::BIP44Account,
+        }
+    }
+
+    fn make_record(
+        tx: dashcore::Transaction,
+        context: TransactionContext,
+        input_details: Vec<InputDetail>,
+        output_details: Vec<OutputDetail>,
+        net_amount: i64,
+    ) -> TransactionRecord {
+        TransactionRecord::new(
+            tx,
+            standard_account_type(),
+            context,
+            TransactionType::Standard,
+            TransactionDirection::Incoming,
+            input_details,
+            output_details,
+            net_amount,
+        )
+    }
 
     fn test_address() -> Address {
         let pk = PublicKey::from_slice(&[
@@ -966,10 +970,13 @@ mod tests {
 
     #[test]
     fn map_sync_event_block_processed() {
+        let mut new_addresses = std::collections::BTreeMap::new();
+        new_addresses.insert([0u8; 32], vec![test_address()]);
         let event = SyncEvent::BlockProcessed {
             block_hash: BlockHash::all_zeros(),
             height: 100,
-            new_addresses: vec![test_address()],
+            wallets: std::collections::BTreeSet::new(),
+            new_addresses,
             confirmed_txids: vec![],
         };
         assert_eq!(
@@ -1063,7 +1070,10 @@ mod tests {
             SyncEvent::BlocksNeeded {
                 blocks: Default::default(),
             },
-            SyncEvent::MasternodeStateUpdated { height: 100 },
+            SyncEvent::MasternodeStateUpdated {
+                height: 100,
+                qr_info_result: None,
+            },
         ];
         for event in unmapped {
             assert_eq!(map_sync_event(event), None);
@@ -1124,30 +1134,30 @@ mod tests {
     }
 
     #[test]
-    fn map_wallet_event_transaction_received() {
+    fn map_wallet_event_transaction_detected() {
         let tx = Transaction::dummy_empty();
         let txid = tx.txid();
-        let record = TransactionRecord::new(
+        let record = make_record(
             tx,
             TransactionContext::Mempool,
-            TransactionType::Standard,
-            TransactionDirection::Incoming,
             Vec::new(),
             Vec::new(),
             50000,
         );
-        let event = WalletEvent::TransactionReceived {
+        let event = WalletEvent::TransactionDetected {
             wallet_id: [0; 32],
-            account_index: 0,
             record: Box::new(record),
+            balance: WalletCoreBalance::new(50000, 0, 0, 0),
+            account_balances: Default::default(),
+            addresses_derived: Vec::new(),
         };
         let mapped = map_wallet_event(event, Network::Mainnet);
-        match mapped {
+        assert_eq!(mapped.len(), 2);
+        match &mapped[0] {
             SpvEvent::TransactionReceived(info) => {
                 assert_eq!(info.txid, txid);
                 assert_eq!(info.amount, 50000);
                 assert_eq!(info.direction, TransactionDirection::Incoming);
-                assert_eq!(info.transaction_type, TransactionType::Standard);
                 assert!(info.addresses.is_empty());
                 assert_eq!(info.height, None);
                 assert!(!info.is_instant_send);
@@ -1155,59 +1165,49 @@ mod tests {
             }
             other => panic!("expected TransactionReceived, got {:?}", other),
         }
-    }
-
-    #[test]
-    fn map_wallet_event_transaction_status_changed() {
-        let txid = Txid::all_zeros();
-        let event = WalletEvent::TransactionStatusChanged {
-            wallet_id: [0; 32],
-            txid,
-            status: TransactionContext::InBlock(BlockInfo::new(
-                300,
-                BlockHash::all_zeros(),
-                1700000000,
-            )),
-        };
-        let mapped = map_wallet_event(event, Network::Mainnet);
-        match mapped {
-            SpvEvent::TransactionReceived(info) => {
-                assert_eq!(info.amount, 0);
-                assert_eq!(info.direction, TransactionDirection::Incoming);
-                assert_eq!(info.transaction_type, TransactionType::Standard);
-                assert_eq!(info.height, Some(300));
-                assert_eq!(info.timestamp, 1700000000);
-                assert!(!info.is_chain_locked);
-            }
-            other => panic!("expected TransactionReceived, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn map_wallet_event_balance_updated() {
-        let event = WalletEvent::BalanceUpdated {
-            wallet_id: [0; 32],
-            spendable: 100_000,
-            unconfirmed: 50_000,
-            immature: 25_000,
-            locked: 10_000,
-        };
-        let mapped = map_wallet_event(event, Network::Mainnet);
         assert_eq!(
-            mapped,
+            mapped[1],
+            SpvEvent::BalanceUpdated(WalletCoreBalance::new(50000, 0, 0, 0))
+        );
+    }
+
+    #[test]
+    fn map_wallet_event_block_processed_emits_balance() {
+        let event = WalletEvent::BlockProcessed {
+            wallet_id: [0; 32],
+            height: 100,
+            inserted: Vec::new(),
+            updated: Vec::new(),
+            matured: Vec::new(),
+            balance: WalletCoreBalance::new(100_000, 50_000, 25_000, 10_000),
+            account_balances: Default::default(),
+            addresses_derived: Vec::new(),
+        };
+        let mapped = map_wallet_event(event, Network::Mainnet);
+        assert_eq!(mapped.len(), 1);
+        assert_eq!(
+            mapped[0],
             SpvEvent::BalanceUpdated(WalletCoreBalance::new(100_000, 50_000, 25_000, 10_000))
         );
+    }
+
+    #[test]
+    fn map_wallet_event_sync_height_advanced_is_empty() {
+        let event = WalletEvent::SyncHeightAdvanced {
+            wallet_id: [0; 32],
+            height: 200,
+        };
+        let mapped = map_wallet_event(event, Network::Mainnet);
+        assert!(mapped.is_empty());
     }
 
     #[test]
     fn from_record_in_block_uses_block_timestamp_over_fallback() {
         let tx = Transaction::dummy_empty();
         let block_hash = BlockHash::all_zeros();
-        let record = TransactionRecord::new(
+        let record = make_record(
             tx,
             TransactionContext::InBlock(BlockInfo::new(500, block_hash, 1700000000)),
-            TransactionType::Standard,
-            TransactionDirection::Incoming,
             Vec::new(),
             Vec::new(),
             42000,
@@ -1218,17 +1218,14 @@ mod tests {
         assert_eq!(info.timestamp, 1700000000);
         assert_eq!(info.height, Some(500));
         assert_eq!(info.direction, TransactionDirection::Incoming);
-        assert_eq!(info.transaction_type, TransactionType::Standard);
     }
 
     #[test]
     fn from_record_mempool_uses_fallback_timestamp() {
         let tx = Transaction::dummy_empty();
-        let record = TransactionRecord::new(
+        let record = make_record(
             tx,
             TransactionContext::Mempool,
-            TransactionType::Standard,
-            TransactionDirection::Incoming,
             Vec::new(),
             Vec::new(),
             10000,
@@ -1276,11 +1273,9 @@ mod tests {
         ];
 
         let tx = Transaction::dummy_empty();
-        let record = TransactionRecord::new(
+        let record = make_record(
             tx,
             TransactionContext::Mempool,
-            TransactionType::Standard,
-            TransactionDirection::Incoming,
             input_details,
             Vec::new(),
             10000,
@@ -1309,11 +1304,9 @@ mod tests {
         ];
 
         let tx = Transaction::dummy_empty();
-        let record = TransactionRecord::new(
+        let record = make_record(
             tx,
             TransactionContext::Mempool,
-            TransactionType::Standard,
-            TransactionDirection::Incoming,
             input_details,
             Vec::new(),
             125_000,
@@ -1336,18 +1329,20 @@ mod tests {
             OutputDetail {
                 index: 0,
                 role: UpstreamTestOutputRole::Received,
+                address: Some(addr.clone()),
+                value: 99_774,
             },
             OutputDetail {
                 index: 1,
                 role: UpstreamTestOutputRole::Change,
+                address: Some(addr.clone()),
+                value: 226,
             },
         ];
 
-        let record = TransactionRecord::new(
+        let record = make_record(
             tx,
             TransactionContext::Mempool,
-            TransactionType::Standard,
-            TransactionDirection::Incoming,
             Vec::new(),
             output_details,
             99_774,
@@ -1372,13 +1367,13 @@ mod tests {
         let output_details = vec![OutputDetail {
             index: 99,
             role: UpstreamTestOutputRole::Sent,
+            address: None,
+            value: 0,
         }];
 
-        let record = TransactionRecord::new(
+        let record = make_record(
             tx,
             TransactionContext::Mempool,
-            TransactionType::Standard,
-            TransactionDirection::Incoming,
             Vec::new(),
             output_details,
             0,

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -1326,6 +1326,35 @@ mod tests {
     }
 
     #[test]
+    fn from_record_non_empty_label_is_preserved() {
+        let tx = Transaction::dummy_empty();
+        let mut record = make_record(
+            tx,
+            TransactionContext::Mempool,
+            Vec::new(),
+            Vec::new(),
+            1_000,
+        );
+        record.label = "grocery store".to_string();
+        let info = TransactionInfo::from_record(&record, 0, Network::Testnet);
+        assert_eq!(info.label, Some("grocery store".to_string()));
+    }
+
+    #[test]
+    fn from_record_empty_label_maps_to_none() {
+        let tx = Transaction::dummy_empty();
+        let record = make_record(
+            tx,
+            TransactionContext::Mempool,
+            Vec::new(),
+            Vec::new(),
+            1_000,
+        );
+        let info = TransactionInfo::from_record(&record, 0, Network::Testnet);
+        assert_eq!(info.label, None);
+    }
+
+    #[test]
     fn extract_record_addresses_deduplicates() {
         let addr_a = test_address();
         // Create a distinct address using a different public key

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -37,7 +37,8 @@ use super::error::{BackendError, BackendResult};
 use super::events::{EventReceiver, EventSender, SpvEvent, event_channel};
 use super::r#trait::SpvBackend;
 use super::types::{
-    InputInfo, Network, OutputInfo, OutputRole, SyncProgress, TransactionInfo, WalletCoreBalance,
+    InputInfo, Network, OutputInfo, OutputRole, SyncProgress, TransactionDirection,
+    TransactionInfo, TransactionType, WalletCoreBalance,
 };
 use crate::config::AppConfig;
 
@@ -662,8 +663,26 @@ fn map_wallet_event(event: WalletEvent, network: Network) -> Vec<SpvEvent> {
             ))),
             SpvEvent::BalanceUpdated(balance),
         ],
-        WalletEvent::TransactionInstantLocked { balance, .. } => {
-            vec![SpvEvent::BalanceUpdated(balance)]
+        WalletEvent::TransactionInstantLocked { txid, balance, .. } => {
+            vec![
+                SpvEvent::TransactionReceived(Box::new(TransactionInfo {
+                    txid,
+                    is_instant_send: true,
+                    amount: 0,
+                    direction: TransactionDirection::Incoming,
+                    transaction_type: TransactionType::Standard,
+                    timestamp: 0,
+                    height: None,
+                    fee: None,
+                    addresses: Vec::new(),
+                    block_hash: None,
+                    is_chain_locked: false,
+                    label: None,
+                    inputs: Vec::new(),
+                    outputs: Vec::new(),
+                })),
+                SpvEvent::BalanceUpdated(balance),
+            ]
         }
         WalletEvent::BlockProcessed {
             inserted,
@@ -1190,6 +1209,74 @@ mod tests {
             mapped[0],
             SpvEvent::BalanceUpdated(WalletCoreBalance::new(100_000, 50_000, 25_000, 10_000))
         );
+    }
+
+    #[test]
+    fn map_wallet_event_block_processed_with_records_emits_transaction_received() {
+        let tx1 = Transaction::dummy_empty();
+        let tx2 = Transaction::dummy_empty();
+        let txid1 = tx1.txid();
+        let txid2 = tx2.txid();
+        let record1 = make_record(
+            tx1,
+            TransactionContext::Mempool,
+            Vec::new(),
+            Vec::new(),
+            10_000,
+        );
+        let record2 = make_record(
+            tx2,
+            TransactionContext::Mempool,
+            Vec::new(),
+            Vec::new(),
+            20_000,
+        );
+        let balance = WalletCoreBalance::new(30_000, 0, 0, 0);
+        let event = WalletEvent::BlockProcessed {
+            wallet_id: [0; 32],
+            height: 200,
+            inserted: vec![record1],
+            updated: vec![record2],
+            matured: Vec::new(),
+            balance,
+            account_balances: Default::default(),
+            addresses_derived: Vec::new(),
+        };
+        let mapped = map_wallet_event(event, Network::Mainnet);
+        assert_eq!(mapped.len(), 3);
+        match &mapped[0] {
+            SpvEvent::TransactionReceived(info) => assert_eq!(info.txid, txid1),
+            other => panic!("expected TransactionReceived, got {:?}", other),
+        }
+        match &mapped[1] {
+            SpvEvent::TransactionReceived(info) => assert_eq!(info.txid, txid2),
+            other => panic!("expected TransactionReceived, got {:?}", other),
+        }
+        assert_eq!(mapped[2], SpvEvent::BalanceUpdated(balance));
+    }
+
+    #[test]
+    fn map_wallet_event_transaction_instant_locked_emits_received_and_balance() {
+        let txid = Txid::from_byte_array([7; 32]);
+        let balance = WalletCoreBalance::new(200_000, 0, 0, 0);
+        let event = WalletEvent::TransactionInstantLocked {
+            wallet_id: [0; 32],
+            txid,
+            instant_lock: InstantLock::default(),
+            balance,
+            account_balances: Default::default(),
+        };
+        let mapped = map_wallet_event(event, Network::Mainnet);
+        assert_eq!(mapped.len(), 2);
+        match &mapped[0] {
+            SpvEvent::TransactionReceived(info) => {
+                assert_eq!(info.txid, txid);
+                assert!(info.is_instant_send);
+                assert_eq!(info.amount, 0);
+            }
+            other => panic!("expected TransactionReceived, got {:?}", other),
+        }
+        assert_eq!(mapped[1], SpvEvent::BalanceUpdated(balance));
     }
 
     #[test]

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -810,6 +810,7 @@ fn extract_context_fields(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
     use std::net::SocketAddr;
 
     use dash_spv::network::NetworkEvent;
@@ -970,12 +971,12 @@ mod tests {
 
     #[test]
     fn map_sync_event_block_processed() {
-        let mut new_addresses = std::collections::BTreeMap::new();
+        let mut new_addresses = BTreeMap::new();
         new_addresses.insert([0u8; 32], vec![test_address()]);
         let event = SyncEvent::BlockProcessed {
             block_hash: BlockHash::all_zeros(),
             height: 100,
-            wallets: std::collections::BTreeSet::new(),
+            wallets: BTreeSet::new(),
             new_addresses,
             confirmed_txids: vec![],
         };

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -309,7 +309,6 @@ impl AppConfig {
             Network::Testnet => "testnet",
             Network::Regtest => "regtest",
             Network::Devnet => "devnet",
-            _ => "devnet",
         }
     }
 


### PR DESCRIPTION
## Summary

- Rebases `xdustinface/rust-dashcore feat/dash-spv-wallet` onto upstream `dashpay/v0.42-dev` (new fork tip `3e1484bf0`, 3 wallet-specific commits on top of upstream `49c8c6dd3`; the squashed PR #615 commit was dropped because it landed upstream as `c1c6a142f`).
- Bumps `Cargo.lock` to the new fork tip and adapts call sites in `src/backend/{ffi,native,mock}.rs` and `src/config/settings.rs` to upstream API changes: `Network` moved to a `dash-network` crate, `ManagedCoreAccount` split into funds/keys variants, `FFIAccountType` renamed to `FFIAccountKind`, `FFIWalletEventCallbacks` reshaped, `TransactionRecord::label` is now `String`, and several wallet/event signature changes.
- Enables the `keep-finalized-transactions` feature on `key-wallet`, `key-wallet-manager`, `key-wallet-ffi` so transaction listings remain available, and adds `dash-network` (feature `ffi`) gated on the `ffi` feature.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` — 339 passed, 0 failed
- [x] `dx fmt --check`
- [x] `dx check`
- [x] `pre-commit run --all-files --hook-stage pre-push` — all 15 hooks pass
- [ ] Manual desktop smoke test: `dx serve --desktop` connects, syncs headers, shows wallet balance, renders a transaction's input/output breakdown

Closes #169
