### PR TITLE
chore: upgrade rust-dashcore to v0.42-dev (bbf0a9c68)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -84,7 +84,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -978,7 +978,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#734df250268437683020c202d289c6bd27086404"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -989,7 +989,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#734df250268437683020c202d289c6bd27086404"
 dependencies = [
  "dash-network",
 ]
@@ -997,7 +997,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#734df250268437683020c202d289c6bd27086404"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1027,7 +1027,7 @@ dependencies = [
 [[package]]
 name = "dash-spv-ffi"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#734df250268437683020c202d289c6bd27086404"
 dependencies = [
  "cbindgen",
  "clap",
@@ -1071,7 +1071,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#734df250268437683020c202d289c6bd27086404"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1097,12 +1097,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#734df250268437683020c202d289c6bd27086404"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#734df250268437683020c202d289c6bd27086404"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1115,7 +1115,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#734df250268437683020c202d289c6bd27086404"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#734df250268437683020c202d289c6bd27086404"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -1651,7 +1651,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1827,7 +1827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1903,12 +1903,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -2237,21 +2231,8 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -2461,20 +2442,11 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -2682,12 +2654,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,8 +2699,6 @@ checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2899,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#734df250268437683020c202d289c6bd27086404"
 dependencies = [
  "aes",
  "async-trait",
@@ -2927,7 +2891,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#734df250268437683020c202d289c6bd27086404"
 dependencies = [
  "cbindgen",
  "dash-network",
@@ -2943,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.42.0"
-source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#3e1484bf023631a8bf9e5d9efac8f81ee5928401"
+source = "git+https://github.com/xdustinface/rust-dashcore?branch=feat%2Fdash-spv-wallet#734df250268437683020c202d289c6bd27086404"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2989,12 +2953,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libappindicator"
@@ -3383,7 +3341,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3964,16 +3922,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4067,12 +4015,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -4345,7 +4287,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4831,7 +4773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5073,10 +5015,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5683,15 +5625,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5747,28 +5680,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.13.1",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5779,18 +5690,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap 2.13.1",
- "semver",
 ]
 
 [[package]]
@@ -5921,7 +5820,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6319,88 +6218,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.13.1",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.1",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.1",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -36,11 +36,9 @@ use dashcore::hashes::Hash;
 use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
 use key_wallet::wallet::initialization::WalletAccountCreationOptions;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
-use key_wallet::wallet::managed_wallet_info::coin_selection::{SelectionError, SelectionStrategy};
+use key_wallet::wallet::managed_wallet_info::coin_selection::SelectionStrategy;
 use key_wallet::wallet::managed_wallet_info::fee::FeeRate;
-use key_wallet::wallet::managed_wallet_info::transaction_builder::{
-    BuilderError, TransactionBuilder,
-};
+use key_wallet::wallet::managed_wallet_info::transaction_builder::TransactionBuilder;
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use key_wallet_ffi::error::FFIError as WalletFFIError;
 use key_wallet_ffi::managed_account::{
@@ -917,7 +915,7 @@ impl SpvBackend for FfiBackend {
             .add_inputs(utxos)
             .build_signed(wallet, path_resolver)
             .await
-            .map_err(builder_error_to_backend)?;
+            .map_err(super::builder_error_to_backend)?;
 
         let txid = tx.txid();
         tracing::debug!(txid = %txid, actual_fee, "transaction built");
@@ -1030,26 +1028,6 @@ fn read_wallet_ffi_error(error: &WalletFFIError) -> String {
 
 fn network_to_ffi(network: Network) -> FFINetwork {
     FFINetwork::from(network)
-}
-
-fn builder_error_to_backend(e: BuilderError) -> BackendError {
-    match e {
-        BuilderError::InsufficientFunds {
-            available,
-            required,
-        } => BackendError::InsufficientFunds {
-            available,
-            required,
-        },
-        BuilderError::CoinSelection(SelectionError::InsufficientFunds {
-            available,
-            required,
-        }) => BackendError::InsufficientFunds {
-            available,
-            required,
-        },
-        other => BackendError::Internal(other.to_string()),
-    }
 }
 
 fn ffi_sync_state_to_rust(state: dash_spv_ffi::types::FFISyncState) -> SyncState {

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -908,7 +908,7 @@ impl SpvBackend for FfiBackend {
         };
 
         let fee = FeeRate::new(fee_rate as u64);
-        let (tx, _fee) = TransactionBuilder::new()
+        let (tx, actual_fee) = TransactionBuilder::new()
             .set_fee_rate(fee)
             .set_change_address(change_address)
             .add_output(&recipient, amount)
@@ -920,6 +920,7 @@ impl SpvBackend for FfiBackend {
             .map_err(builder_error_to_backend)?;
 
         let txid = tx.txid();
+        tracing::debug!(txid = %txid, actual_fee, "transaction built");
 
         // Serialize and broadcast via FFI
         let tx_bytes = dashcore::consensus::serialize(&tx);

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -33,14 +33,14 @@ use dash_spv_ffi::types::{
     FFISyncProgress,
 };
 use dashcore::hashes::Hash;
-use key_wallet::DerivationPathBuilder;
 use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
-use key_wallet::managed_account::managed_account_type::ManagedAccountType;
 use key_wallet::wallet::initialization::WalletAccountCreationOptions;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
-use key_wallet::wallet::managed_wallet_info::coin_selection::SelectionStrategy;
+use key_wallet::wallet::managed_wallet_info::coin_selection::{SelectionError, SelectionStrategy};
 use key_wallet::wallet::managed_wallet_info::fee::FeeRate;
-use key_wallet::wallet::managed_wallet_info::transaction_builder::TransactionBuilder;
+use key_wallet::wallet::managed_wallet_info::transaction_builder::{
+    BuilderError, TransactionBuilder,
+};
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use key_wallet_ffi::error::FFIError as WalletFFIError;
 use key_wallet_ffi::managed_account::{
@@ -361,12 +361,11 @@ impl SpvBackend for FfiBackend {
             let mut error = WalletFFIError::default();
 
             // Safety: wm is valid (just obtained), c_mnemonic is a valid C string,
-            // passphrase is null (empty passphrase), error is a valid stack variable.
+            // error is a valid stack variable.
             let ok = unsafe {
                 wallet_manager_add_wallet_from_mnemonic(
                     wm as *mut key_wallet_ffi::FFIWalletManager,
                     c_mnemonic.as_ptr(),
-                    std::ptr::null(),
                     &mut error,
                 )
             };
@@ -418,7 +417,6 @@ impl SpvBackend for FfiBackend {
                 wallet_manager_add_wallet_from_mnemonic(
                     wm as *mut key_wallet_ffi::FFIWalletManager,
                     c_mnemonic.as_ptr(),
-                    std::ptr::null(),
                     &mut error,
                 )
             };
@@ -698,7 +696,6 @@ impl SpvBackend for FfiBackend {
         let wallet_id = local_wm
             .create_wallet_from_mnemonic(
                 &mnemonic_str,
-                "",
                 0,
                 WalletAccountCreationOptions::SpecificAccounts(
                     BTreeSet::from([0]),
@@ -901,87 +898,28 @@ impl SpvBackend for FfiBackend {
 
         let tip_height = self.tip_height().unwrap_or(0);
         let accounts = info.accounts();
-        let coin_type = coin_type_for_network(network);
 
-        // Build the key provider closure that derives private keys for UTXOs
-        let key_provider = |utxo: &key_wallet::Utxo| -> Option<dashcore::secp256k1::SecretKey> {
-            for (account_index, account) in &accounts.standard_bip44_accounts {
-                if let ManagedAccountType::Standard {
-                    external_addresses,
-                    internal_addresses,
-                    ..
-                } = account.managed_account_type()
-                {
-                    if let Some(addr_idx) = external_addresses.address_index(&utxo.address) {
-                        let path = DerivationPathBuilder::new()
-                            .coin_type(coin_type)
-                            .account(*account_index)
-                            .change(0)
-                            .address_index(addr_idx)
-                            .bip44()
-                            .ok()?;
-                        return wallet.derive_private_key(&path).ok();
-                    }
-                    if let Some(addr_idx) = internal_addresses.address_index(&utxo.address) {
-                        let path = DerivationPathBuilder::new()
-                            .coin_type(coin_type)
-                            .account(*account_index)
-                            .change(1)
-                            .address_index(addr_idx)
-                            .bip44()
-                            .ok()?;
-                        return wallet.derive_private_key(&path).ok();
-                    }
-                }
-            }
-
-            for (account_index, account) in &accounts.standard_bip32_accounts {
-                if let ManagedAccountType::Standard {
-                    external_addresses,
-                    internal_addresses,
-                    ..
-                } = account.managed_account_type()
-                {
-                    if let Some(addr_idx) = external_addresses.address_index(&utxo.address) {
-                        let path = DerivationPathBuilder::new()
-                            .account(*account_index)
-                            .change(0)
-                            .address_index(addr_idx)
-                            .build()
-                            .ok()?;
-                        return wallet.derive_private_key(&path).ok();
-                    }
-                    if let Some(addr_idx) = internal_addresses.address_index(&utxo.address) {
-                        let path = DerivationPathBuilder::new()
-                            .account(*account_index)
-                            .change(1)
-                            .address_index(addr_idx)
-                            .build()
-                            .ok()?;
-                        return wallet.derive_private_key(&path).ok();
-                    }
-                }
-            }
-
-            None
+        // Resolve the derivation path for an input address by searching the
+        // standard BIP44 accounts first, then the BIP32 accounts.
+        let path_resolver = |address: dashcore::Address| -> Option<key_wallet::DerivationPath> {
+            accounts
+                .standard_bip44_accounts
+                .values()
+                .chain(accounts.standard_bip32_accounts.values())
+                .find_map(|account| account.address_derivation_path(&address))
         };
 
-        // Build the transaction
         let fee = FeeRate::new(fee_rate as u64);
-        let mut builder = TransactionBuilder::new()
+        let (tx, _fee) = TransactionBuilder::new()
             .set_fee_rate(fee)
             .set_change_address(change_address)
             .add_output(&recipient, amount)
-            .map_err(|e| BackendError::Internal(e.to_string()))?
-            .select_inputs(
-                &utxos,
-                SelectionStrategy::BranchAndBound,
-                tip_height,
-                key_provider,
-            )
+            .set_selection_strategy(SelectionStrategy::BranchAndBound)
+            .set_current_height(tip_height)
+            .add_inputs(utxos)
+            .build_signed(wallet, path_resolver)
+            .await
             .map_err(builder_error_to_backend)?;
-
-        let tx = builder.build().map_err(builder_error_to_backend)?;
 
         let txid = tx.txid();
 
@@ -1095,20 +1033,7 @@ fn network_to_ffi(network: Network) -> FFINetwork {
     FFINetwork::from(network)
 }
 
-/// Return the BIP44 coin type for the given network.
-fn coin_type_for_network(network: Network) -> u32 {
-    match network {
-        Network::Mainnet => 5,
-        _ => 1,
-    }
-}
-
-fn builder_error_to_backend(
-    e: key_wallet::wallet::managed_wallet_info::transaction_builder::BuilderError,
-) -> BackendError {
-    use key_wallet::wallet::managed_wallet_info::coin_selection::SelectionError;
-    use key_wallet::wallet::managed_wallet_info::transaction_builder::BuilderError;
-
+fn builder_error_to_backend(e: BuilderError) -> BackendError {
     match e {
         BuilderError::InsufficientFunds {
             available,
@@ -1281,6 +1206,7 @@ fn build_wallet_callbacks(user_data: *mut c_void) -> FFIWalletEventCallbacks {
         on_transaction_instant_locked: Some(on_transaction_instant_locked),
         on_block_processed: Some(on_wallet_block_processed),
         on_sync_height_advanced: None,
+        on_transactions_chainlocked: None,
         user_data,
     }
 }
@@ -1617,6 +1543,9 @@ extern "C" fn on_wallet_block_processed(
     _account_balances_count: u32,
     _addresses_derived: *const dash_spv_ffi::callbacks::FFIDerivedAddress,
     _addresses_derived_count: u32,
+    _cl_height: u32,
+    _cl_hash: *const [u8; 32],
+    _cl_signature: *const [u8; 96],
     user_data: *mut c_void,
 ) {
     // Safety: user_data is a valid CallbackContext pointer (borrowed, not owned).
@@ -2318,6 +2247,9 @@ mod tests {
             0,
             ptr::null(),
             0,
+            0,
+            ptr::null(),
+            ptr::null(),
             user_data,
         );
 
@@ -2378,6 +2310,9 @@ mod tests {
             0,
             ptr::null(),
             0,
+            0,
+            ptr::null(),
+            ptr::null(),
             user_data,
         );
 
@@ -2416,6 +2351,9 @@ mod tests {
             0,
             ptr::null(),
             0,
+            0,
+            ptr::null(),
+            ptr::null(),
             user_data,
         );
 

--- a/src/backend/ffi.rs
+++ b/src/backend/ffi.rs
@@ -899,8 +899,6 @@ impl SpvBackend for FfiBackend {
         let tip_height = self.tip_height().unwrap_or(0);
         let accounts = info.accounts();
 
-        // Resolve the derivation path for an input address by searching the
-        // standard BIP44 accounts first, then the BIP32 accounts.
         let path_resolver = |address: dashcore::Address| -> Option<key_wallet::DerivationPath> {
             accounts
                 .standard_bip44_accounts

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,5 +1,10 @@
 use std::path::Path;
 
+use key_wallet::wallet::managed_wallet_info::coin_selection::SelectionError;
+use key_wallet::wallet::managed_wallet_info::transaction_builder::BuilderError;
+
+use self::error::BackendError;
+
 pub mod dispatch;
 pub mod error;
 pub mod events;
@@ -9,6 +14,26 @@ pub mod mock;
 pub mod native;
 pub mod r#trait;
 pub mod types;
+
+fn builder_error_to_backend(e: BuilderError) -> BackendError {
+    match e {
+        BuilderError::InsufficientFunds {
+            available,
+            required,
+        } => BackendError::InsufficientFunds {
+            available,
+            required,
+        },
+        BuilderError::CoinSelection(SelectionError::InsufficientFunds {
+            available,
+            required,
+        }) => BackendError::InsufficientFunds {
+            available,
+            required,
+        },
+        other => BackendError::Internal(other.to_string()),
+    }
+}
 
 /// Recursively compute the total size of a directory.
 fn dir_size(dir: &Path) -> u64 {

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -1198,6 +1198,21 @@ mod tests {
     }
 
     #[test]
+    fn map_wallet_event_transactions_chainlocked_is_empty() {
+        let event = WalletEvent::TransactionsChainlocked {
+            wallet_id: [0; 32],
+            chain_lock: ChainLock {
+                block_height: 0,
+                block_hash: BlockHash::all_zeros(),
+                signature: BLSSignature::from([0; 96]),
+            },
+            per_account: BTreeMap::new(),
+        };
+        let mapped = map_wallet_event(event, Network::Mainnet);
+        assert!(mapped.is_empty());
+    }
+
+    #[test]
     fn from_record_in_block_uses_block_timestamp_over_fallback() {
         let tx = Transaction::dummy_empty();
         let block_hash = BlockHash::all_zeros();

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -22,10 +22,8 @@ use key_wallet::mnemonic::Language;
 use key_wallet::transaction_checking::TransactionContext;
 use key_wallet::wallet::initialization::WalletAccountCreationOptions;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
-use key_wallet::wallet::managed_wallet_info::coin_selection::SelectionError;
 use key_wallet::wallet::managed_wallet_info::coin_selection::SelectionStrategy;
 use key_wallet::wallet::managed_wallet_info::fee::FeeRate;
-use key_wallet::wallet::managed_wallet_info::transaction_builder::BuilderError;
 use key_wallet::wallet::managed_wallet_info::transaction_builder::TransactionBuilder;
 use key_wallet::wallet::managed_wallet_info::transaction_building::AccountTypePreference;
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
@@ -450,23 +448,7 @@ impl SpvBackend for NativeBackend {
             .add_inputs(utxos)
             .build_signed(wallet, path_resolver)
             .await
-            .map_err(|e| match e {
-                BuilderError::InsufficientFunds {
-                    available,
-                    required,
-                } => BackendError::InsufficientFunds {
-                    available,
-                    required,
-                },
-                BuilderError::CoinSelection(SelectionError::InsufficientFunds {
-                    available,
-                    required,
-                }) => BackendError::InsufficientFunds {
-                    available,
-                    required,
-                },
-                other => BackendError::Internal(other.to_string()),
-            })?;
+            .map_err(super::builder_error_to_backend)?;
 
         let txid = tx.txid();
         tracing::debug!(txid = %txid, actual_fee, "transaction built");

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -432,8 +432,6 @@ impl SpvBackend for NativeBackend {
         let tip_height = self.tip_height().unwrap_or(0);
         let accounts = info.accounts();
 
-        // Resolve the derivation path for an input address by searching the
-        // standard BIP44 accounts first, then the BIP32 accounts.
         let path_resolver = |address: dashcore::Address| -> Option<key_wallet::DerivationPath> {
             accounts
                 .standard_bip44_accounts

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -441,7 +441,7 @@ impl SpvBackend for NativeBackend {
         };
 
         let fee = FeeRate::new(fee_rate as u64);
-        let (tx, _fee) = TransactionBuilder::new()
+        let (tx, actual_fee) = TransactionBuilder::new()
             .set_fee_rate(fee)
             .set_change_address(change_address)
             .add_output(&recipient, amount)
@@ -469,6 +469,7 @@ impl SpvBackend for NativeBackend {
             })?;
 
         let txid = tx.txid();
+        tracing::debug!(txid = %txid, actual_fee, "transaction built");
 
         // Drop the wallet lock before broadcasting
         drop(wallet_guard);

--- a/src/backend/native.rs
+++ b/src/backend/native.rs
@@ -13,8 +13,8 @@ use dash_spv::storage::DiskStorageManager;
 use dash_spv::sync::SyncEvent;
 use dash_spv::{ClientConfig, DashSpvClient, MempoolStrategy};
 use dashcore::hashes::Hash;
+use key_wallet::Mnemonic;
 use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
-use key_wallet::managed_account::managed_account_type::ManagedAccountType;
 use key_wallet::managed_account::transaction_record::{
     OutputRole as UpstreamOutputRole, TransactionRecord,
 };
@@ -29,7 +29,6 @@ use key_wallet::wallet::managed_wallet_info::transaction_builder::BuilderError;
 use key_wallet::wallet::managed_wallet_info::transaction_builder::TransactionBuilder;
 use key_wallet::wallet::managed_wallet_info::transaction_building::AccountTypePreference;
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
-use key_wallet::{DerivationPathBuilder, Mnemonic};
 use key_wallet_manager::{WalletEvent, WalletManager};
 use tokio_util::sync::CancellationToken;
 
@@ -268,7 +267,6 @@ impl SpvBackend for NativeBackend {
         wallet
             .create_wallet_from_mnemonic(
                 mnemonic,
-                "",
                 0,
                 WalletAccountCreationOptions::SpecificAccounts(
                     BTreeSet::from([0]),
@@ -304,7 +302,6 @@ impl SpvBackend for NativeBackend {
         wallet
             .create_wallet_from_mnemonic(
                 &mnemonic,
-                "",
                 0,
                 WalletAccountCreationOptions::SpecificAccounts(
                     BTreeSet::from([0]),
@@ -427,94 +424,34 @@ impl SpvBackend for NativeBackend {
                 BackendError::Internal("failed to generate change address".to_string())
             })?;
 
-        // Get wallet reference for key derivation
+        // Get wallet reference for signing and the managed accounts for path resolution
         let (wallet, info) = wallet_guard
             .get_wallet_and_info(wallet_id)
             .ok_or(BackendError::NoWallet)?;
 
         let tip_height = self.tip_height().unwrap_or(0);
-        let network = self.config.network;
         let accounts = info.accounts();
 
-        // Build the key provider closure that derives private keys for UTXOs
-        let key_provider = |utxo: &key_wallet::Utxo| -> Option<dashcore::secp256k1::SecretKey> {
-            // Search BIP44 accounts first, then BIP32
-            for (account_index, account) in &accounts.standard_bip44_accounts {
-                if let ManagedAccountType::Standard {
-                    external_addresses,
-                    internal_addresses,
-                    ..
-                } = account.managed_account_type()
-                {
-                    // Check external (receive) addresses
-                    if let Some(addr_idx) = external_addresses.address_index(&utxo.address) {
-                        let path = DerivationPathBuilder::new()
-                            .coin_type(coin_type_for_network(network))
-                            .account(*account_index)
-                            .change(0)
-                            .address_index(addr_idx)
-                            .bip44()
-                            .ok()?;
-                        return wallet.derive_private_key(&path).ok();
-                    }
-                    // Check internal (change) addresses
-                    if let Some(addr_idx) = internal_addresses.address_index(&utxo.address) {
-                        let path = DerivationPathBuilder::new()
-                            .coin_type(coin_type_for_network(network))
-                            .account(*account_index)
-                            .change(1)
-                            .address_index(addr_idx)
-                            .bip44()
-                            .ok()?;
-                        return wallet.derive_private_key(&path).ok();
-                    }
-                }
-            }
-
-            for (account_index, account) in &accounts.standard_bip32_accounts {
-                if let ManagedAccountType::Standard {
-                    external_addresses,
-                    internal_addresses,
-                    ..
-                } = account.managed_account_type()
-                {
-                    if let Some(addr_idx) = external_addresses.address_index(&utxo.address) {
-                        let path = DerivationPathBuilder::new()
-                            .account(*account_index)
-                            .change(0)
-                            .address_index(addr_idx)
-                            .build()
-                            .ok()?;
-                        return wallet.derive_private_key(&path).ok();
-                    }
-                    if let Some(addr_idx) = internal_addresses.address_index(&utxo.address) {
-                        let path = DerivationPathBuilder::new()
-                            .account(*account_index)
-                            .change(1)
-                            .address_index(addr_idx)
-                            .build()
-                            .ok()?;
-                        return wallet.derive_private_key(&path).ok();
-                    }
-                }
-            }
-
-            None
+        // Resolve the derivation path for an input address by searching the
+        // standard BIP44 accounts first, then the BIP32 accounts.
+        let path_resolver = |address: dashcore::Address| -> Option<key_wallet::DerivationPath> {
+            accounts
+                .standard_bip44_accounts
+                .values()
+                .chain(accounts.standard_bip32_accounts.values())
+                .find_map(|account| account.address_derivation_path(&address))
         };
 
-        // Build the transaction
         let fee = FeeRate::new(fee_rate as u64);
-        let mut builder = TransactionBuilder::new()
+        let (tx, _fee) = TransactionBuilder::new()
             .set_fee_rate(fee)
             .set_change_address(change_address)
             .add_output(&recipient, amount)
-            .map_err(|e| BackendError::Internal(e.to_string()))?
-            .select_inputs(
-                &utxos,
-                SelectionStrategy::BranchAndBound,
-                tip_height,
-                key_provider,
-            )
+            .set_selection_strategy(SelectionStrategy::BranchAndBound)
+            .set_current_height(tip_height)
+            .add_inputs(utxos)
+            .build_signed(wallet, path_resolver)
+            .await
             .map_err(|e| match e {
                 BuilderError::InsufficientFunds {
                     available,
@@ -532,17 +469,6 @@ impl SpvBackend for NativeBackend {
                 },
                 other => BackendError::Internal(other.to_string()),
             })?;
-
-        let tx = builder.build().map_err(|e| match e {
-            BuilderError::InsufficientFunds {
-                available,
-                required,
-            } => BackendError::InsufficientFunds {
-                available,
-                required,
-            },
-            other => BackendError::Internal(other.to_string()),
-        })?;
 
         let txid = tx.txid();
 
@@ -576,14 +502,6 @@ impl SpvBackend for NativeBackend {
 
     fn subscribe_events(&self) -> EventReceiver {
         self.event_tx.subscribe()
-    }
-}
-
-/// Return the BIP44 coin type for the given network.
-fn coin_type_for_network(network: Network) -> u32 {
-    match network {
-        Network::Mainnet => 5,
-        _ => 1,
     }
 }
 
@@ -701,6 +619,7 @@ fn map_wallet_event(event: WalletEvent, network: Network) -> Vec<SpvEvent> {
             events
         }
         WalletEvent::SyncHeightAdvanced { .. } => Vec::new(),
+        WalletEvent::TransactionsChainlocked { .. } => Vec::new(),
     }
 }
 
@@ -886,18 +805,6 @@ mod tests {
         ])
         .unwrap();
         Address::p2pkh(&pk, Network::Testnet)
-    }
-
-    #[test]
-    fn coin_type_mainnet_returns_5() {
-        assert_eq!(coin_type_for_network(Network::Mainnet), 5);
-    }
-
-    #[test]
-    fn coin_type_non_mainnet_returns_1() {
-        assert_eq!(coin_type_for_network(Network::Testnet), 1);
-        assert_eq!(coin_type_for_network(Network::Regtest), 1);
-        assert_eq!(coin_type_for_network(Network::Devnet), 1);
     }
 
     #[test]
@@ -1196,6 +1103,7 @@ mod tests {
         let event = WalletEvent::BlockProcessed {
             wallet_id: [0; 32],
             height: 100,
+            chain_lock: None,
             inserted: Vec::new(),
             updated: Vec::new(),
             matured: Vec::new(),
@@ -1235,6 +1143,7 @@ mod tests {
         let event = WalletEvent::BlockProcessed {
             wallet_id: [0; 32],
             height: 200,
+            chain_lock: None,
             inserted: vec![record1],
             updated: vec![record2],
             matured: Vec::new(),


### PR DESCRIPTION
## Summary

- Bumps the pinned `xdustinface/rust-dashcore` fork from `3e1484bf0` to `734df2502` (= upstream `v0.42-dev` commit `bbf0a9c68` + the 2 wallet-specific patches `Network::currency_unit()` and `WalletFile::unique_txid_count()`).
- Drops the fork's `managed_core_account_set_transaction_label` FFI commit — it is now upstream via PR #618. dash-spv-wallet has no call site for it, so this is a no-op here.
- Adapts both backends to the v0.42-dev API changes:
  - `create_wallet_from_mnemonic` lost its passphrase argument (upstream `MnemonicWithPassphrase` removal) — dropped the `""` arg at all call sites.
  - `TransactionBuilder` centralization: `send()` rewritten to use `build_signed(wallet, path_resolver)` with `account.address_derivation_path()`, replacing the manual per-UTXO key-provider and the hardcoded `coin_type_for_network` helper (now removed). The structured `InsufficientFunds { available, required }` error mapping is preserved.
  - Chainlock handling: added no-op handling for the new `WalletEvent::TransactionsChainlocked` arm and the new `BlockProcessed` chainlock fields / FFI callback params, consistent with the existing `SyncHeightAdvanced` treatment. Existing chainlock UI flow via `SyncEvent::ChainLockReceived` is unchanged.
  - Removed dead imports and helpers surfaced by the above.

## Scope note

The actual API delta is **18 upstream commits** between the old pin `3e1484bf0` and the new base `bbf0a9c68` (issue #172's body cites "110 commits" — that figure was computed against a stale local `dev`; the merged PR #170 had already advanced the pin to `3e1484bf0`). The breaking changes that mattered here were #747 (`MnemonicWithPassphrase` removal), #744 (`TransactionBuilder` centralization), and #756 (chainlock handling).

## Verification

- `cargo fmt --check`, `dx fmt --check`, `dx check` — clean
- `cargo clippy --all-targets -- -D warnings` (default + `--features ffi`) — clean
- `cargo test` (default + `--features ffi`) — all pass (the 2/3 ignored integration tests are pre-existing `#[ignore]`, issue #42)
- Desktop smoke test (`dx serve --desktop`) — connects, syncs headers, shows balance, renders a transaction's input/output breakdown

Closes #172
